### PR TITLE
Remove macOS autorelease pool

### DIFF
--- a/pugl/detail/mac.h
+++ b/pugl/detail/mac.h
@@ -54,7 +54,6 @@
 
 struct PuglWorldInternalsImpl {
 	NSApplication*     app;
-	NSAutoreleasePool* autoreleasePool;
 };
 
 struct PuglInternalsImpl {

--- a/pugl/detail/mac.m
+++ b/pugl/detail/mac.m
@@ -776,7 +776,6 @@ puglInitWorldInternals(PuglWorldType PUGL_UNUSED(type),
 		1, sizeof(PuglWorldInternals));
 
 	impl->app             = [NSApplication sharedApplication];
-	impl->autoreleasePool = [NSAutoreleasePool new];
 
 	return impl;
 }
@@ -784,7 +783,6 @@ puglInitWorldInternals(PuglWorldType PUGL_UNUSED(type),
 void
 puglFreeWorldInternals(PuglWorld* world)
 {
-	[world->impl->autoreleasePool drain];
 	free(world->impl);
 }
 


### PR DESCRIPTION
Hello. Every time, on macOS, I will get a similar crash report when closing the Carla window which hosts my UI (VST3).

It's the draining of `autoreleasePool`, when destroying the Pugl world.
After deleting the releasepool code from Pugl, the problem stops happening.

Does it have any adverse effect to delete it?

Note: I tried debugging the program for memory errors, be it malloc gard / asan, in search of what may be another origin of this problem. It didn't detect any, all I ever saw is this backtrace of NSAutoreleasePool.

Perhaps it's my plugin-side Mac code which get mixed with this autorelease thing, I've no idea.

```
objc[77530]: autorelease pool page 0x7f9bbf95e000 corrupted
  magic     0x00000000 0x00000000 0x00000000 0x00000000
  should be 0xa1a1a1a1 0x4f545541 0x454c4552 0x21455341
  pthread   0x10e6435c0
  should be 0x10e6435c0

Abort trap: 6
```