### PR TITLE
win: SwapBuffers with OpenGL only

### DIFF
--- a/pugl/detail/win.c
+++ b/pugl/detail/win.c
@@ -1100,7 +1100,6 @@ puglWinStubLeave(PuglView* view, const PuglEventExpose* expose)
 	if (expose) {
 		PAINTSTRUCT ps;
 		EndPaint(view->impl->hwnd, &ps);
-		SwapBuffers(view->impl->hdc);
 	}
 
 	return PUGL_SUCCESS;

--- a/pugl/detail/win_cairo.c
+++ b/pugl/detail/win_cairo.c
@@ -153,7 +153,6 @@ puglWinCairoLeave(PuglView* view, const PuglEventExpose* expose)
 
 		PAINTSTRUCT ps;
 		EndPaint(view->impl->hwnd, &ps);
-		SwapBuffers(view->impl->hdc);
 	}
 
 	return PUGL_SUCCESS;


### PR DESCRIPTION
Using the cairo backend on Windows (wine), `SwapBuffers` would crash the program.

Most likely, this API relates to OpenGL only.
MSDN classifies it under OpenGL along with all of wgl API.
https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-swapbuffers

Not verified on real Windows but I suppose the fix to make sense for this case.
