### PR TITLE
Minor cursor tweaks for Mac and Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Jordan Halase <jordan@halase.me>
 Oliver Schmidt <oliver@luced.de>
 Zoë Sparks <zoe@milky.flowers>
 Jean Pierre Cimalando <jp-dev@inbox.ru>
+Thomas Brand <tom@trellis.ch>

--- a/pugl/detail/mac.m
+++ b/pugl/detail/mac.m
@@ -354,6 +354,11 @@ handleCrossing(PuglWrapperView* view, NSEvent* event, const PuglEventType type)
 	puglview->impl->mouseTracked = false;
 }
 
+- (void) cursorUpdate:(NSEvent*)event
+{
+	[puglview->impl->cursor set];
+}
+
 - (void) mouseMoved:(NSEvent*)event
 {
 	const NSPoint         wloc = [self eventLocation:event];

--- a/pugl/detail/win.c
+++ b/pugl/detail/win.c
@@ -546,6 +546,10 @@ handleMessage(PuglView* view, UINT message, WPARAM wParam, LPARAM lParam)
 		if (LOWORD(lParam) == HTCLIENT) {
 			SetCursor(view->impl->cursor);
 		}
+		else
+		{
+			return DefWindowProc(view->impl->hwnd, message, wParam, lParam);
+		}
 		break;
 	case WM_SHOWWINDOW:
 		if (wParam) {


### PR DESCRIPTION
On Mac:
Handle the following case:
-Set mouse cursor when window got focus

Test:
-Start pugl_cursor_demo
-Click outside of window
-Click inside window -> cursor doesn't change without this patch, only after leaving / entering with the mouse while window has focus.

Side-topic: should PUGL_POINTER_IN / OUT be emitted when window got focus via mouse click?

On Windows:
The cursor set by pugl also appears on window borders, minimize / maximize buttons etc.
Forwarding WM_SETCURSOR if it wasn't set by pugl will show standard resize etc. cursors on window borders.

Test: start pugl program, move mouse towards and over the window border.