### PR TITLE
Fix narrowing compiler warnings

### DIFF
--- a/src/mac_gl.m
+++ b/src/mac_gl.m
@@ -73,8 +73,8 @@
     NSOpenGLPFAColorSize,     colorSize,
     NSOpenGLPFADepthSize,     (unsigned)puglview->hints[PUGL_DEPTH_BITS],
     NSOpenGLPFAStencilSize,   (unsigned)puglview->hints[PUGL_STENCIL_BITS],
-    NSOpenGLPFAMultisample,   samples ? 1 : 0,
-    NSOpenGLPFASampleBuffers, samples ? 1 : 0,
+    NSOpenGLPFAMultisample,   (NSOpenGLPixelFormatAttribute)(samples ? 1 : 0),
+    NSOpenGLPFASampleBuffers, (NSOpenGLPixelFormatAttribute)(samples ? 1 : 0),
     NSOpenGLPFASamples,       samples,
     0};
   // clang-format on

--- a/src/win.c
+++ b/src/win.c
@@ -451,7 +451,7 @@ initKeyEvent(PuglEventKey* event,
 static void
 initCharEvent(PuglEvent* event, PuglView* view, WPARAM wParam, LPARAM lParam)
 {
-  const wchar_t utf16[2] = {wParam & 0xFFFF,
+  const wchar_t utf16[2] = {(wchar_t)(wParam & 0xFFFF),
                             (wchar_t)((wParam >> 16) & 0xFFFF)};
 
   initKeyEvent(&event->key, view, true, wParam, lParam);


### PR DESCRIPTION
Pretty straight forward.
The macOS one is very odd that the compiler was complaining about converting integers, my guess is that NSOpenGLPixelFormatAttribute is less than 32bits in size.
