### PR TITLE
Make win32 puglSetFrame consistent with x11

### DIFF
--- a/src/win.c
+++ b/src/win.c
@@ -975,8 +975,6 @@ puglSetWindowTitle(PuglView* view, const char* title)
 PuglStatus
 puglSetFrame(PuglView* view, const PuglRect frame)
 {
-  view->frame = frame;
-
   if (view->impl->hwnd) {
     RECT rect = {(long)frame.x,
                  (long)frame.y,
@@ -997,6 +995,7 @@ puglSetFrame(PuglView* view, const PuglRect frame)
     }
   }
 
+  view->frame = frame;
   return PUGL_SUCCESS;
 }
 


### PR DESCRIPTION
The x11 code only sets frame if `XMoveResizeWindow` succeeds.
This makes the win32 code behave the same way, it will only set the frame if `SetWindowPos` succeeds.

