### PR TITLE
RFC: Allow to setup an X11 event filter

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -1129,6 +1129,10 @@ dispatchX11Events(PuglWorld* const world)
       continue;
     }
 
+    if (world->impl->eventFilter && world->impl->eventFilter(display, &xevent)) {
+      continue;
+    }
+
     PuglView* view = findView(world, xevent.xany.window);
     if (!view) {
       continue;
@@ -1468,6 +1472,12 @@ puglX11Configure(PuglView* view)
   view->hints[PUGL_GREEN_BITS] = impl->vi->bits_per_rgb;
   view->hints[PUGL_BLUE_BITS]  = impl->vi->bits_per_rgb;
   view->hints[PUGL_ALPHA_BITS] = 0;
+  return PUGL_SUCCESS;
+}
 
+PuglStatus
+puglX11SetEventFilter(PuglWorld* world, PuglX11EventFilter filter)
+{
+  world->impl->eventFilter = filter;
   return PUGL_SUCCESS;
 }

--- a/src/x11.h
+++ b/src/x11.h
@@ -29,6 +29,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+typedef bool (*PuglX11EventFilter)(Display*, XEvent*);
+
 typedef struct {
   Atom CLIPBOARD;
   Atom UTF8_STRING;
@@ -57,6 +59,7 @@ struct PuglWorldInternalsImpl {
   int          syncEventBase;
   bool         syncSupported;
   bool         dispatchingEvents;
+  PuglX11EventFilter eventFilter;
 };
 
 struct PuglInternalsImpl {
@@ -76,5 +79,8 @@ struct PuglInternalsImpl {
 PUGL_API
 PuglStatus
 puglX11Configure(PuglView* view);
+
+PuglStatus
+puglX11SetEventFilter(PuglWorld* world, PuglX11EventFilter filter);
 
 #endif // PUGL_DETAIL_X11_H


### PR DESCRIPTION
This might be a bit controversial, but I found that I need this if I am going to not keep a forked pugl.

These changes allow to plug in other custom x11 code on top of pugl, that handles its own windows, events etc.
Tested to work with DPF and https://github.com/x42/sofd/

I tried to make it as generic as possible.