### PR TITLE
Clear macOS GL context after creating window and initial size

### DIFF
--- a/src/mac_gl.m
+++ b/src/mac_gl.m
@@ -94,6 +94,7 @@
   if (self) {
     [[self openGLContext] makeCurrentContext];
     [self reshape];
+    [NSOpenGLContext clearCurrentContext];
   }
   return self;
 }


### PR DESCRIPTION
Run into issues when using multiple GL UIs with pugl.
Opening new GL UI can mess up the state of existing UIs.
This was partly at fault.
