### PR TITLE
macOS event loop fixes

### DIFF
--- a/src/mac.m
+++ b/src/mac.m
@@ -1174,23 +1174,21 @@ PuglStatus
 puglSendEvent(PuglView* view, const PuglEvent* event)
 {
   if (event->type == PUGL_CLIENT) {
-    PuglWrapperView* wrapper = view->impl->wrapperView;
-    const NSWindow*  window  = [wrapper window];
-    const NSRect     rect    = [wrapper frame];
-    const NSPoint    center  = {NSMidX(rect), NSMidY(rect)};
+    PuglEvent copiedEvent = *event;
 
-    NSEvent* nsevent =
-      [NSEvent otherEventWithType:NSApplicationDefined
-                         location:center
-                    modifierFlags:0
-                        timestamp:[[NSProcessInfo processInfo] systemUptime]
-                     windowNumber:window.windowNumber
-                          context:nil
-                          subtype:PUGL_CLIENT
-                            data1:(NSInteger)event->client.data1
-                            data2:(NSInteger)event->client.data2];
+    CFRunLoopObserverRef observer = CFRunLoopObserverCreateWithHandler(
+      NULL,
+      kCFRunLoopAfterWaiting,
+      false,
+      0,
+      ^(CFRunLoopObserverRef, CFRunLoopActivity) {
+        puglDispatchEvent(view, &copiedEvent);
+      });
 
-    [view->world->impl->app postEvent:nsevent atStart:false];
+    CFRunLoopAddObserver(CFRunLoopGetMain(), observer, kCFRunLoopCommonModes);
+
+    CFRelease(observer);
+
     return PUGL_SUCCESS;
   }
 
@@ -1205,48 +1203,27 @@ puglWaitForEvent(PuglView* view)
 }
 #endif
 
-static void
-dispatchClientEvent(PuglWorld* world, NSEvent* ev)
-{
-  NSWindow* win = [ev window];
-  NSPoint   loc = [ev locationInWindow];
-  for (size_t i = 0; i < world->numViews; ++i) {
-    PuglView*        view    = world->views[i];
-    PuglWrapperView* wrapper = view->impl->wrapperView;
-    if ([wrapper window] == win && NSPointInRect(loc, [wrapper frame])) {
-      const PuglClientEvent event = {
-        PUGL_CLIENT, 0, (uintptr_t)[ev data1], (uintptr_t)[ev data2]};
-
-      PuglEvent clientEvent;
-      clientEvent.client = event;
-      puglDispatchEvent(view, &clientEvent);
-    }
-  }
-}
-
 PuglStatus
 puglUpdate(PuglWorld* world, const double timeout)
 {
   @autoreleasepool {
-    NSDate* date =
-      ((timeout < 0) ? [NSDate distantFuture]
-                     : [NSDate dateWithTimeIntervalSinceNow:timeout]);
+    if (world->impl->autoreleasePool != nil) {
+      NSDate* date =
+        ((timeout < 0) ? [NSDate distantFuture]
+                       : [NSDate dateWithTimeIntervalSinceNow:timeout]);
 
-    for (NSEvent* ev = NULL;
-         (ev = [world->impl->app nextEventMatchingMask:NSAnyEventMask
-                                             untilDate:date
-                                                inMode:NSDefaultRunLoopMode
-                                               dequeue:YES]);) {
-      if ([ev type] == NSApplicationDefined && [ev subtype] == (NSEventSubtype)PUGL_CLIENT) {
-        dispatchClientEvent(world, ev);
-      }
+      for (NSEvent* ev = NULL;
+           (ev = [world->impl->app nextEventMatchingMask:NSAnyEventMask
+                                               untilDate:date
+                                                  inMode:NSDefaultRunLoopMode
+                                                 dequeue:YES]);) {
+        [world->impl->app sendEvent:ev];
 
-      [world->impl->app sendEvent:ev];
-
-      if (timeout < 0) {
-        // Now that we've waited and got an event, set the date to now to avoid
-        // looping forever
-        date = [NSDate date];
+        if (timeout < 0) {
+          // Now that we've waited and got an event, set the date to now to
+          // avoid looping forever
+          date = [NSDate date];
+        }
       }
     }
 

--- a/test/test_redisplay.c
+++ b/test/test_redisplay.c
@@ -55,6 +55,22 @@ typedef struct {
 static const PuglRect  redisplayRect   = {2, 4, 8, 16};
 static const uintptr_t postRedisplayId = 42;
 
+static bool
+rectContains(PuglRect outer, PuglRect inner)
+{
+  return outer.x <= inner.x && outer.y <= inner.y &&
+         inner.x + inner.width <= outer.x + outer.width &&
+         inner.y + inner.height <= outer.y + outer.height;
+}
+
+static PuglRect
+getExposeRect(PuglExposeEvent event)
+{
+  PuglRect result = {
+    .x = event.x, .y = event.y, .width = event.width, .height = event.height};
+  return result;
+}
+
 static PuglStatus
 onEvent(PuglView* view, const PuglEvent* event)
 {
@@ -76,10 +92,7 @@ onEvent(PuglView* view, const PuglEvent* event)
     if (test->state == START) {
       test->state = EXPOSED;
     } else if (test->state == POSTED_REDISPLAY &&
-               event->expose.x == redisplayRect.x &&
-               event->expose.y == redisplayRect.y &&
-               event->expose.width == redisplayRect.width &&
-               event->expose.height == redisplayRect.height) {
+               rectContains(getExposeRect(event->expose), redisplayRect)) {
       test->state = REDISPLAYED;
     }
     break;


### PR DESCRIPTION
When running pugl as a PUGL_MODULE, it's dangerous to call `sendEvent` on arbitrary events, as processing such events could cause the UI instance to be destroyed. Then, when statements later on in `puglUpdate` are executed, they may attempt to access resources that have been freed, crashing the process. This is currently seen in LV2 UIs which execute puglUpdate from the idle callback.

This change just posts events to the CFRunLoop directly, which seems a bit cleaner. This way, there's no need to convert the event to an NSEvent and back, as we can just capture the event in a block instead.

I also noticed that the test_redisplay app asserts on Big Sur because the OS invalidates the entire window in response to the invalidate request, so I've updated the test a little to be slightly more forgiving about mismatches between the requested and actual repainted areas.

Finally, I noticed that the meson build currently doesn't work out-of-the-box due to undefined references to `c_warnings` and `objc_warnings`. Perhaps this is a configuration issue on my system, so I haven't pushed a fix. That said, removing the references allowed the build to succeed.

See also #56 and https://github.com/DISTRHO/DPF/issues/299.