### PR TITLE
RFC: Possible fix for macOS transient windows always visible

### DIFF
--- a/src/mac.m
+++ b/src/mac.m
@@ -1036,10 +1036,14 @@ puglRealize(PuglView* view)
     puglSetFrame(view, view->frame);
 
     [window setContentView:impl->wrapperView];
-    [view->world->impl->app activateIgnoringOtherApps:YES];
     [window makeFirstResponder:impl->wrapperView];
-    [window makeKeyAndOrderFront:window];
-    [impl->window setIsVisible:NO];
+    [window setIsVisible:NO];
+
+    if (! view->transientParent)
+    {
+      [window makeKeyAndOrderFront:window];
+      [view->world->impl->app activateIgnoringOtherApps:YES];
+    }
   }
 
   [impl->wrapperView updateTrackingAreas];


### PR DESCRIPTION
pugl supports transient parent windows, for which the parent is not something to embed but just something to place below a window on the "WM window list stack".

I have an issue when creating 2 views, one is a transient parent to the other.
It works fine everywhere except macOS.

on macOS, having `makeKeyAndOrderFront` will always make the window visible on screen.
Making the window key seems wrong in this case, the key window should be the transient parent, not the "child"/top window.

Comments welcome, I verified that this patch works correctly for my use case