### PR TITLE
Fix build under macOS 10.8 (NSEventSubtype type not available)

### DIFF
--- a/src/mac.m
+++ b/src/mac.m
@@ -29,6 +29,10 @@
 
 #include <stdlib.h>
 
+#ifndef __MAC_10_9
+typedef NSUInteger NSEventSubtype;
+#endif
+
 #ifndef __MAC_10_10
 typedef NSUInteger NSEventModifierFlags;
 #endif


### PR DESCRIPTION
This is a pretty simple one.
I am targeting 10.8 as the base macOS to build from, a small check similar to others already in place is all that is needed to get pugl working on 10.8
