### PR TITLE
Check for xrandr extension before usage

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -366,12 +366,15 @@ puglRealize(PuglView* const view)
   }
 
 #ifdef HAVE_XRANDR
-  // Set refresh rate hint to the real refresh rate
-  XRRScreenConfiguration* conf         = XRRGetScreenInfo(display, parent);
-  short                   current_rate = XRRConfigCurrentRate(conf);
+  if (XRRQueryExtension(display, NULL, NULL))
+  {
+    // Set refresh rate hint to the real refresh rate
+    XRRScreenConfiguration* conf         = XRRGetScreenInfo(display, parent);
+    short                   current_rate = XRRConfigCurrentRate(conf);
 
-  view->hints[PUGL_REFRESH_RATE] = current_rate;
-  XRRFreeScreenConfigInfo(conf);
+    view->hints[PUGL_REFRESH_RATE] = current_rate;
+    XRRFreeScreenConfigInfo(conf);
+  }
 #endif
 
   updateSizeHints(view);

--- a/src/x11.c
+++ b/src/x11.c
@@ -366,7 +366,8 @@ puglRealize(PuglView* const view)
   }
 
 #ifdef HAVE_XRANDR
-  if (XRRQueryExtension(display, NULL, NULL))
+  int ignored;
+  if (XRRQueryExtension(display, &ignored, &ignored))
   {
     // Set refresh rate hint to the real refresh rate
     XRRScreenConfiguration* conf         = XRRGetScreenInfo(display, parent);


### PR DESCRIPTION
There might be a situation where xrandr is enabled in the build, but it is not provided/supported by the x11 server.
One such case is X11 forwarding over SSH.
On such setups `XRRGetScreenInfo` crashes the whole application.

This PR fixes the issue by checking if xrandr is available before attempting to use it.
