### PR TITLE
Add diagonal cursors

### DIFF
--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -1251,13 +1251,15 @@ puglPostRedisplayRect(PuglView* view, PuglRect rect);
    Windows.
 */
 typedef enum {
-  PUGL_CURSOR_ARROW,      ///< Default pointing arrow
-  PUGL_CURSOR_CARET,      ///< Caret (I-Beam) for text entry
-  PUGL_CURSOR_CROSSHAIR,  ///< Cross-hair
-  PUGL_CURSOR_HAND,       ///< Hand with a pointing finger
-  PUGL_CURSOR_NO,         ///< Operation not allowed
-  PUGL_CURSOR_LEFT_RIGHT, ///< Left/right arrow for horizontal resize
-  PUGL_CURSOR_UP_DOWN,    ///< Up/down arrow for vertical resize
+  PUGL_CURSOR_ARROW,         ///< Default pointing arrow
+  PUGL_CURSOR_CARET,         ///< Caret (I-Beam) for text entry
+  PUGL_CURSOR_CROSSHAIR,     ///< Cross-hair
+  PUGL_CURSOR_HAND,          ///< Hand with a pointing finger
+  PUGL_CURSOR_NO,            ///< Operation not allowed
+  PUGL_CURSOR_LEFT_RIGHT,    ///< Left/right arrow for horizontal resize
+  PUGL_CURSOR_UP_DOWN,       ///< Up/down arrow for vertical resize
+  PUGL_CURSOR_DIAGONAL,      ///< Top-left to bottom-right arrow for diagonal resize
+  PUGL_CURSOR_ANTI_DIAGONAL, ///< Bottom-left to top-right arrow for diagonal resize
 } PuglCursor;
 
 /**

--- a/src/mac.m
+++ b/src/mac.m
@@ -1668,6 +1668,8 @@ puglGetClipboard(PuglView* const view,
 static NSCursor*
 puglGetNsCursor(const PuglCursor cursor)
 {
+  SEL cursorSelector = nil;
+
   switch (cursor) {
   case PUGL_CURSOR_ARROW:
     return [NSCursor arrowCursor];
@@ -1683,6 +1685,19 @@ puglGetNsCursor(const PuglCursor cursor)
     return [NSCursor resizeLeftRightCursor];
   case PUGL_CURSOR_UP_DOWN:
     return [NSCursor resizeUpDownCursor];
+  case PUGL_CURSOR_DIAGONAL:
+    cursorSelector = @selector(_windowResizeNorthWestSouthEastCursor);
+    break;
+  case PUGL_CURSOR_ANTI_DIAGONAL:
+    cursorSelector = @selector(_windowResizeNorthEastSouthWestCursor);
+    break;
+  }
+
+  if (cursorSelector && [NSCursor respondsToSelector:cursorSelector])
+  {
+    const id object = [NSCursor performSelector:cursorSelector];
+    if ([object isKindOfClass:[NSCursor class]])
+      return (NSCursor*)object;
   }
 
   return NULL;

--- a/src/win.c
+++ b/src/win.c
@@ -1284,13 +1284,15 @@ puglPaste(PuglView* const view)
 }
 
 static const char* const cursor_ids[] = {
-  IDC_ARROW,  // ARROW
-  IDC_IBEAM,  // CARET
-  IDC_CROSS,  // CROSSHAIR
-  IDC_HAND,   // HAND
-  IDC_NO,     // NO
-  IDC_SIZEWE, // LEFT_RIGHT
-  IDC_SIZENS, // UP_DOWN
+  IDC_ARROW,    // ARROW
+  IDC_IBEAM,    // CARET
+  IDC_CROSS,    // CROSSHAIR
+  IDC_HAND,     // HAND
+  IDC_NO,       // NO
+  IDC_SIZEWE,   // LEFT_RIGHT
+  IDC_SIZENS,   // UP_DOWN
+  IDC_SIZENWSE, // DIAGONAL
+  IDC_SIZENESW, // ANTI_DIAGONAL
 };
 
 PuglStatus

--- a/src/x11.c
+++ b/src/x11.c
@@ -65,7 +65,7 @@ enum WmClientStateMessageAction {
   WM_STATE_TOGGLE
 };
 
-#define NUM_CURSORS ((unsigned)PUGL_CURSOR_UP_DOWN + 1u)
+#define NUM_CURSORS ((unsigned)PUGL_CURSOR_ANTI_DIAGONAL + 1u)
 
 static const char* const cursor_names[NUM_CURSORS] = {
   "default",           // ARROW
@@ -74,7 +74,9 @@ static const char* const cursor_names[NUM_CURSORS] = {
   "pointer",           // HAND
   "not-allowed",       // NO
   "sb_h_double_arrow", // LEFT_RIGHT
-  "sb_v_double_arrow"  // UP_DOWN
+  "sb_v_double_arrow", // UP_DOWN
+  "size_fdiag",        // DIAGONAL
+  "size_bdiag"         // ANTI_DIAGONAL
 };
 
 static bool


### PR DESCRIPTION
This is a WIP changeset to:
1. add diagonal cursor types (done on X11, not yet on other platforms)
2. use X11 cursor names instead of predefined macros (which lack the diagonal cursors, among others)

Note: I had to remove the first `defineCursorShape(view, impl->cursorShape);` on the view creation as it leads to a crash.
The `cursorShape` (now renamed `cursorName`) is set to the default value, so it does not have any visible difference.

Fixes #73

I will try to implement the diagonal cursors for macOS and Windows soon.

@drobilla any opinions on this, should I do it some other way?
