### PR TITLE
Make X11GlEnter fail if the window is not realized

### DIFF
--- a/src/mac_gl.m
+++ b/src/mac_gl.m
@@ -135,6 +135,9 @@ static PuglStatus
 puglMacGlEnter(PuglView* view, const PuglExposeEvent* PUGL_UNUSED(expose))
 {
   PuglOpenGLView* const drawView = (PuglOpenGLView*)view->impl->drawView;
+  if (!drawView) {
+    return PUGL_FAILURE;
+  }
 
   [[drawView openGLContext] makeCurrentContext];
   return PUGL_SUCCESS;

--- a/src/win_gl.c
+++ b/src/win_gl.c
@@ -258,6 +258,9 @@ static PuglStatus
 puglWinGlEnter(PuglView* view, const PuglExposeEvent* expose)
 {
   PuglWinGlSurface* surface = (PuglWinGlSurface*)view->impl->surface;
+  if (!surface || !surface->hglrc) {
+    return PUGL_FAILURE;
+  }
 
   wglMakeCurrent(view->impl->hdc, surface->hglrc);
 

--- a/src/x11_gl.c
+++ b/src/x11_gl.c
@@ -103,6 +103,9 @@ static PuglStatus
 puglX11GlEnter(PuglView* view, const PuglExposeEvent* PUGL_UNUSED(expose))
 {
   PuglX11GlSurface* surface = (PuglX11GlSurface*)view->impl->surface;
+  if (!surface || !surface->ctx) {
+    return PUGL_FAILURE;
+  }
 
   return glXMakeCurrent(view->impl->display, view->impl->win, surface->ctx)
            ? PUGL_SUCCESS

--- a/test/meson.build
+++ b/test/meson.build
@@ -65,7 +65,8 @@ cairo_tests = [
 
 gl_tests = [
   'gl',
-  'gl_hints'
+  'gl_free_unrealized',
+  'gl_hints',
 ]
 
 vulkan_tests = [

--- a/test/test_gl_free_unrealized.c
+++ b/test/test_gl_free_unrealized.c
@@ -1,0 +1,59 @@
+// Copyright 2022 David Robillard <d@drobilla.net>
+// SPDX-License-Identifier: ISC
+
+/*
+  Tests that deleting an unrealized view works properly.
+
+  This was a crash bug with OpenGL backends.
+*/
+
+#undef NDEBUG
+
+#include "test_utils.h"
+
+#include "pugl/gl.h"
+#include "pugl/pugl.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct {
+  PuglWorld*      world;
+  PuglView*       view;
+  PuglTestOptions opts;
+} PuglTest;
+
+static PuglStatus
+onEvent(PuglView* const view, const PuglEvent* const event)
+{
+  PuglTest* const test = (PuglTest*)puglGetHandle(view);
+
+  if (test->opts.verbose) {
+    printEvent(event, "Event: ", true);
+  }
+
+  return PUGL_SUCCESS;
+}
+
+int
+main(int argc, char** argv)
+{
+  PuglTest test = {
+    puglNewWorld(PUGL_PROGRAM, 0), NULL, puglParseTestOptions(&argc, &argv)};
+
+  // Set up view
+  test.view = puglNewView(test.world);
+  puglSetClassName(test.world, "Pugl Test");
+  puglSetWindowTitle(test.view, "Pugl Free View Test");
+  puglSetBackend(test.view, puglGlBackend());
+  puglSetHandle(test.view, &test);
+  puglSetEventFunc(test.view, onEvent);
+  puglSetDefaultSize(test.view, 512, 512);
+
+  // Tear everything down without ever realizing the view
+  puglFreeView(test.view);
+  puglFreeWorld(test.world);
+
+  return 0;
+}


### PR DESCRIPTION
When a GL view is created, and then destroyed before its realization,
the event PUGL_DESTROY dispatches and attempts to enter the
uninitialized GL context, producing a crash.