### PR TITLE
Bad locale

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -460,13 +460,13 @@ puglRealize(PuglView* const view)
   // Create input context
   if (world->impl->xim) {
     impl->xic = XCreateIC(world->impl->xim,
-			  XNInputStyle,
-			  XIMPreeditNothing | XIMStatusNothing,
-			  XNClientWindow,
-			  impl->win,
-			  XNFocusWindow,
-			  impl->win,
-			  (XIM)0);
+                          XNInputStyle,
+                          XIMPreeditNothing | XIMStatusNothing,
+                          XNClientWindow,
+                          impl->win,
+                          XNFocusWindow,
+                          impl->win,
+                          (XIM)0);
   }
 
   puglDispatchSimpleEvent(view, PUGL_CREATE);
@@ -1397,10 +1397,10 @@ dispatchX11Events(PuglWorld* const world)
       }
     } else if (xevent.type == FocusIn) {
       if (impl->xic)
-	XSetICFocus(impl->xic);
+        XSetICFocus(impl->xic);
     } else if (xevent.type == FocusOut) {
       if (impl->xic)
-	XUnsetICFocus(impl->xic);
+        XUnsetICFocus(impl->xic);
     } else if (xevent.type == SelectionClear) {
       PuglX11Clipboard* const board =
         getX11SelectionClipboard(view, xevent.xselectionclear.selection);

--- a/src/x11.c
+++ b/src/x11.c
@@ -175,6 +175,7 @@ puglInitWorldInternals(const PuglWorldType type, const PuglWorldFlags flags)
   if (!(impl->xim = XOpenIM(display, NULL, NULL, NULL))) {
     XSetLocaleModifiers("@im=");
     impl->xim = XOpenIM(display, NULL, NULL, NULL);
+    // impl->xim could still be NULL, if in a container without full locales
   }
 
   initXSync(impl);
@@ -457,14 +458,16 @@ puglRealize(PuglView* const view)
   }
 
   // Create input context
-  impl->xic = XCreateIC(world->impl->xim,
-                        XNInputStyle,
-                        XIMPreeditNothing | XIMStatusNothing,
-                        XNClientWindow,
-                        impl->win,
-                        XNFocusWindow,
-                        impl->win,
-                        (XIM)0);
+  if (world->impl->xim) {
+    impl->xic = XCreateIC(world->impl->xim,
+			  XNInputStyle,
+			  XIMPreeditNothing | XIMStatusNothing,
+			  XNClientWindow,
+			  impl->win,
+			  XNFocusWindow,
+			  impl->win,
+			  (XIM)0);
+  }
 
   puglDispatchSimpleEvent(view, PUGL_CREATE);
 
@@ -619,7 +622,7 @@ translateKey(PuglView* const view, XEvent* const xevent, PuglEvent* const event)
   event->key.key =
     ((special || ufound <= 0) ? special : puglDecodeUTF8((const uint8_t*)ustr));
 
-  if (xevent->type == KeyPress && !filter && !special) {
+  if (xevent->type == KeyPress && !filter && !special && view->impl->xic) {
     // Lookup shifted key for possible text event
     xevent->xkey.state = state;
 
@@ -1393,9 +1396,11 @@ dispatchX11Events(PuglWorld* const world)
         continue;
       }
     } else if (xevent.type == FocusIn) {
-      XSetICFocus(impl->xic);
+      if (impl->xic)
+	XSetICFocus(impl->xic);
     } else if (xevent.type == FocusOut) {
-      XUnsetICFocus(impl->xic);
+      if (impl->xic)
+	XUnsetICFocus(impl->xic);
     } else if (xevent.type == SelectionClear) {
       PuglX11Clipboard* const board =
         getX11SelectionClipboard(view, xevent.xselectionclear.selection);


### PR DESCRIPTION
I encountered a SIGSEGV crash when running Aether in a docker container running the official archlinux image.  The immediate cause was XUnsetICFocus being called with an argument of NULL.

Upon investigation, I found that the creators of the archlinux image have aggressively pruned /usr/share/X11/locale such that XOpenIM fails and returns NULL.  This causes XCreateIC to also return NULL, and finally crash the program when a FocusOut event arrives.  (The FocusIn doesn't crash because XSetICFocus happens to be safe to call with NULL.)

I was able to get the Aether plugin to run by putting a check around the call to XUnsetICFocus in src/x11.c or by populating the missing files /usr/share/X11/locale/C and /usr/share/X11/locale/iso8859-1.

This PR attempts to be a more complete defense than just putting a check around XSetICFocus, but unfortunately, I don't have a good way to set up my test environment again.  I hope this will be useful nonetheless.

I will also try to contact the archlinux image builders and ask that they make /usr/share/X11/locale complete enough that XOpenIM will succeed.

Thanks for your library!