### PR TITLE
x11.c: Fix missing field initializers in C++ mode

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -949,7 +949,7 @@ puglGrabFocus(PuglView* const view)
 {
   PuglInternals* const impl    = view->impl;
   Display* const       display = view->world->impl->display;
-  XWindowAttributes    attrs   = {0};
+  XWindowAttributes    attrs   = PUGL_INIT_STRUCT;
 
   if (!impl->win || !XGetWindowAttributes(display, impl->win, &attrs)) {
     return PUGL_UNKNOWN_ERROR;
@@ -978,7 +978,7 @@ puglRequestAttention(PuglView* const view)
   PuglInternals* const      impl    = view->impl;
   Display* const            display = view->world->impl->display;
   const PuglX11Atoms* const atoms   = &view->world->impl->atoms;
-  XEvent                    event   = {0};
+  XEvent                    event   = PUGL_INIT_STRUCT;
 
   event.type                 = ClientMessage;
   event.xclient.window       = impl->win;
@@ -1079,7 +1079,7 @@ puglStopTimer(PuglView* const view, const uintptr_t id)
 static XEvent
 eventToX(PuglView* const view, const PuglEvent* const event)
 {
-  XEvent xev          = {0};
+  XEvent xev          = PUGL_INIT_STRUCT;
   xev.xany.send_event = True;
 
   switch (event->type) {


### PR DESCRIPTION
Fixes a warning when building in C++ mode.
We simply use the macro that was defined in that same file for this.

```
src/pugl-upstream/src/x11.c: In function ‘DGL::PuglStatus DGL::puglGrabFocus(DGL::PuglView*)’:
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::y’ [-Wmissing-field-initializers]
  954 |   XWindowAttributes    attrs   = {0};
      |                                    ^
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::width’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::height’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::border_width’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::depth’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::visual’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::root’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::c_class’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::bit_gravity’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::win_gravity’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::backing_store’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::backing_planes’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::backing_pixel’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::save_under’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::colormap’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::map_installed’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::map_state’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::all_event_masks’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::your_event_mask’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::do_not_propagate_mask’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::override_redirect’ [-Wmissing-field-initializers]
src/pugl-upstream/src/x11.c:954:36: warning: missing initializer for member ‘XWindowAttributes::screen’ [-Wmissing-field-initializers]
```