### PR TITLE
Use CLOCK_UPTIME_RAW for macOS time

### DIFF
--- a/src/mac.m
+++ b/src/mac.m
@@ -1400,7 +1400,7 @@ puglProcessEvents(PuglView* view)
 double
 puglGetTime(const PuglWorld* world)
 {
-  return (mach_absolute_time() / 1e9) - world->startTime;
+  return (clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / 1e9) - world->startTime;
 }
 
 PuglStatus


### PR DESCRIPTION
I was having an issue where in standalone mode under macOS (not hosted by a DAW) some plugin graphics were running very, very slow.
After a bit of debug turns out the value returned by `puglGetTime` was quite different from running as app bundle / standalone vs hosted in a DAW.

pugl is simply calling `mach_absolute_time`, so maybe something is wrong there.
According to https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time

> Prefer to use the equivalent clock_gettime_nsec_np(CLOCK_UPTIME_RAW) in nanoseconds

Which I tried, and now the behaviour is consistent when standalone and in a DAW.
I do not know why it is that way.

PS: I tried `mach_continuous_time` but that showed the same slow-running issues.
