### PR TITLE
Avoid using undefined c_warnings variable

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -148,8 +148,12 @@ if host_machine.system() == 'darwin'
     ]
   endif
 
+  if get_option('strict')
+    objcpp_args += c_warnings
+  endif
+
   unified_args += objcpp.get_supported_arguments(
-    c_warnings + test_cpp_args + objcpp_args)
+    test_cpp_args + objcpp_args)
 
   executable('inline_objcpp', 'test_inline_objcpp.mm',
              include_directories: include_directories(includes),


### PR DESCRIPTION
The `c_warnings` doesn't get defined unless `-Dstrict=true`.  `test/meson.build` tries to access it when building for OSX and fails. Unless strict is enabled, this happens:

```
mfisher@computer pugl % meson setup build
The Meson build system
Version: 0.63.0
Source dir: /Users/mfisher/workspace/lad/pugl
Build dir: /Users/mfisher/workspace/lad/pugl/build
Build type: native build
Project name: pugl
Project version: 0.4.0
C compiler for the host machine: ccache cc (clang 12.0.0 "Apple clang version 12.0.0 (clang-1200.0.32.29)")
C linker for the host machine: cc ld64 609.8
Host machine cpu family: x86_64
Host machine cpu: x86_64
C++ compiler for the host machine: ccache c++ (clang 12.0.0 "Apple clang version 12.0.0 (clang-1200.0.32.29)")
C++ linker for the host machine: c++ ld64 609.8
Objective-C compiler for the host machine: ccache cc (clang 12.0.0)
Objective-C linker for the host machine: cc ld64 609.8
Library dl found: YES
Found pkg-config: /usr/local/bin/pkg-config (0.29.2)
Run-time dependency cocoa found: YES (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Cocoa.framework)
Run-time dependency corevideo found: YES (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreVideo.framework)
Library m found: YES
Run-time dependency gl found: YES
Run-time dependency cairo found: YES 1.16.0
Compiler for C supports arguments -Wno-documentation: YES
Compiler for C supports arguments -Wno-documentation-unknown-command: YES
Compiler for C supports arguments -Wno-reserved-identifier: NO
Run-time dependency vulkan found: NO (tried pkgconfig and system)
Program reuse found: NO
Objective-C++ compiler for the host machine: ccache c++ (clang 12.0.0)
Objective-C++ linker for the host machine: c++ ld64 609.8

test/meson.build:151:2: ERROR: Unknown variable "c_warnings".
```

I searched the code base and it appears `c_warnings` is used outside of the suppression stuff only  once... and only on Mac.  This patch appends c_warnings to the tests if strict is enabled.  I didn't see in the meson docs a way to check for undefined variables (maybe I'm missing something), so I went this route.
