### PR TITLE
Add include_directories to pugl_dep.

### DIFF
--- a/examples/pugl_cairo_demo.app/MacOS/meson.build
+++ b/examples/pugl_cairo_demo.app/MacOS/meson.build
@@ -1,7 +1,7 @@
 executable(
   'pugl_cairo_demo',
   ['../../pugl_cairo_demo.c'],
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args + cairo_args,
   cpp_args: example_defines + example_cpp_args,
   dependencies: [pugl_dep, cairo_backend_dep])

--- a/examples/pugl_clipboard_demo.app/MacOS/meson.build
+++ b/examples/pugl_clipboard_demo.app/MacOS/meson.build
@@ -4,6 +4,6 @@
 executable(
   'pugl_clipboard_demo',
   '../../pugl_clipboard_demo.c',
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   dependencies: [pugl_dep, gl_backend_dep])

--- a/examples/pugl_cpp_demo.app/MacOS/meson.build
+++ b/examples/pugl_cpp_demo.app/MacOS/meson.build
@@ -1,7 +1,7 @@
 executable(
   'pugl_cpp_demo',
   '../../pugl_cpp_demo.cpp',
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   cpp_args: example_defines + example_cpp_args,
   dependencies: [puglpp_dep, gl_backend_dep])

--- a/examples/pugl_cursor_demo.app/MacOS/meson.build
+++ b/examples/pugl_cursor_demo.app/MacOS/meson.build
@@ -1,7 +1,7 @@
 executable(
   'pugl_cursor_demo',
   '../../pugl_cursor_demo.c',
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   cpp_args: example_defines + example_cpp_args,
   dependencies: [pugl_dep, gl_backend_dep])

--- a/examples/pugl_embed_demo.app/MacOS/meson.build
+++ b/examples/pugl_embed_demo.app/MacOS/meson.build
@@ -1,7 +1,7 @@
 executable(
   'pugl_embed_demo',
   '../../pugl_embed_demo.c',
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   cpp_args: example_defines + example_cpp_args,
   dependencies: [pugl_dep, gl_backend_dep])

--- a/examples/pugl_shader_demo.app/MacOS/meson.build
+++ b/examples/pugl_shader_demo.app/MacOS/meson.build
@@ -5,7 +5,7 @@ executable(
     '../../glad/glad.c',
     '../../pugl_shader_demo.c',
   ],
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   cpp_args: example_defines + example_cpp_args,
   dependencies: [pugl_dep, gl_backend_dep, dl_dep])

--- a/examples/pugl_vulkan_cpp_demo.app/MacOS/meson.build
+++ b/examples/pugl_vulkan_cpp_demo.app/MacOS/meson.build
@@ -4,7 +4,7 @@ executable(
     '../../pugl_vulkan_cpp_demo.cpp',
     '../../file_utils.c',
   ],
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   cpp_args: example_defines + example_cpp_args,
   dependencies: [puglpp_dep, vulkan_backend_dep])

--- a/examples/pugl_vulkan_demo.app/MacOS/meson.build
+++ b/examples/pugl_vulkan_demo.app/MacOS/meson.build
@@ -4,6 +4,6 @@ executable(
     '../../pugl_vulkan_demo.c',
     '../../file_utils.c',
   ],
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   dependencies: [pugl_dep, vulkan_backend_dep])

--- a/examples/pugl_window_demo.app/MacOS/meson.build
+++ b/examples/pugl_window_demo.app/MacOS/meson.build
@@ -1,7 +1,7 @@
 executable(
   'pugl_window_demo',
   '../../pugl_window_demo.c',
-  include_directories: include_directories('../../../../include', '../../..'),
+  include_directories: include_directories('../../..'),
   c_args: example_defines + example_c_args,
   cpp_args: example_defines + example_cpp_args,
   dependencies: [pugl_dep, gl_backend_dep])

--- a/meson.build
+++ b/meson.build
@@ -166,7 +166,9 @@ libpugl = build_target(
   install: true,
   target_type: library_type)
 
-pugl_dep = declare_dependency(link_with: libpugl, dependencies: core_deps)
+pugl_dep = declare_dependency(link_with: libpugl, 
+                              dependencies: core_deps,
+                              include_directories: [ 'include' ])
 
 pkg.generate(libpugl,
              name: 'Pugl',


### PR DESCRIPTION
Had more errors on Mac.  The OSX apps were reaching one directory back to far (`'../../../../include'`) to a non-existent folder.   I assume `include` is public headers,  so I added it to include_directories on the `pugl_dep` object.  Fixes these mac errors and also probably good when used as a subproject.

```
pugl| subprojects/pugl/examples/pugl_cairo_demo.app/MacOS/meson.build:4: WARNING: include_directories sandbox violation!
The project is trying to access the directory **'../../../../include'** which belongs to a different
subproject. This is a problem as it hardcodes the relative paths of these two projects.
This makes it impossible to compile the project in any other directory layout and also
prevents the subproject from changing its own directory layout.

Instead of poking directly at the internals the subproject should be executed and
it should set a variable that the caller can then use. Something like:

# In subproject
some_dep = declare_dependency(include_directories: include_directories('include'))

# In subproject wrap file
[provide]
some = some_dep

# In parent project
some_dep = dependency('some')
executable(..., dependencies: [some_dep])

This warning will become a hard error in a future Meson release.


subprojects/pugl/examples/pugl_cairo_demo.app/MacOS/meson.build:1:0: ERROR: Include dir ../../../../include does not exist.
```
