### PR TITLE
Replace deprecated typedefs

### DIFF
--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -1615,10 +1615,10 @@ PUGL_DEPRECATED_BY("PuglUnrealizeEvent")
 typedef PuglUnrealizeEvent PuglDestroyEvent;
 
 PUGL_DEPRECATED_BY("PuglRealizeEvent")
-typedef PuglCreateEvent PuglEventCreate;
+typedef PuglRealizeEvent PuglEventCreate;
 
 PUGL_DEPRECATED_BY("PuglUnrealizeEvent")
-typedef PuglDestroyEvent PuglEventDestroy;
+typedef PuglUnrealizeEvent PuglEventDestroy;
 
 PUGL_DEPRECATED_BY("PuglConfigureEvent")
 typedef PuglConfigureEvent PuglEventConfigure;


### PR DESCRIPTION
The double deprecated typedefs left a deprecated symbol in the API. And this always causes compiler warnings. Simply omitted by using the recent replaced_by typedef.