### PR TITLE
Enable puglSetPositionHint prior puglRealize

### DIFF
--- a/examples/pugl_embed_demo.c
+++ b/examples/pugl_embed_demo.c
@@ -109,23 +109,23 @@ onKeyPress(PuglView* view, const PuglKeyEvent* event)
     app->quit = 1;
   } else if (event->state & PUGL_MOD_SHIFT) {
     if (event->key == PUGL_KEY_UP) {
-      puglSetSize(view, frame.width, frame.height - 10U);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width, frame.height - 10U);
     } else if (event->key == PUGL_KEY_DOWN) {
-      puglSetSize(view, frame.width, frame.height + 10U);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width, frame.height + 10U);
     } else if (event->key == PUGL_KEY_LEFT) {
-      puglSetSize(view, frame.width - 10U, frame.height);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width - 10U, frame.height);
     } else if (event->key == PUGL_KEY_RIGHT) {
-      puglSetSize(view, frame.width + 10U, frame.height);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width + 10U, frame.height);
     }
   } else {
     if (event->key == PUGL_KEY_UP) {
-      puglSetPosition(view, frame.x, frame.y - 10);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x, frame.y - 10);
     } else if (event->key == PUGL_KEY_DOWN) {
-      puglSetPosition(view, frame.x, frame.y + 10);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x, frame.y + 10);
     } else if (event->key == PUGL_KEY_LEFT) {
-      puglSetPosition(view, frame.x - 10, frame.y);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x - 10, frame.y);
     } else if (event->key == PUGL_KEY_RIGHT) {
-      puglSetPosition(view, frame.x + 10, frame.y);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x + 10, frame.y);
     }
   }
 }

--- a/examples/pugl_window_demo.c
+++ b/examples/pugl_window_demo.c
@@ -70,23 +70,23 @@ onKeyPress(PuglView* view, const PuglKeyEvent* event)
     app->quit = 1;
   } else if (event->state & PUGL_MOD_SHIFT) {
     if (event->key == PUGL_KEY_UP) {
-      puglSetSize(view, frame.width, frame.height - 10U);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width, frame.height - 10U);
     } else if (event->key == PUGL_KEY_DOWN) {
-      puglSetSize(view, frame.width, frame.height + 10U);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width, frame.height + 10U);
     } else if (event->key == PUGL_KEY_LEFT) {
-      puglSetSize(view, frame.width - 10U, frame.height);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width - 10U, frame.height);
     } else if (event->key == PUGL_KEY_RIGHT) {
-      puglSetSize(view, frame.width + 10U, frame.height);
+      puglSetSizeHint(view, PUGL_USER_SIZE, frame.width + 10U, frame.height);
     }
   } else {
     if (event->key == PUGL_KEY_UP) {
-      puglSetPosition(view, frame.x, frame.y - 10);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x, frame.y - 10);
     } else if (event->key == PUGL_KEY_DOWN) {
-      puglSetPosition(view, frame.x, frame.y + 10);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x, frame.y + 10);
     } else if (event->key == PUGL_KEY_LEFT) {
-      puglSetPosition(view, frame.x - 10, frame.y);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x - 10, frame.y);
     } else if (event->key == PUGL_KEY_RIGHT) {
-      puglSetPosition(view, frame.x + 10, frame.y);
+      puglSetPositionHint(view, PUGL_USER_POSITION, frame.x + 10, frame.y);
     }
   }
 }
@@ -186,9 +186,10 @@ main(int argc, char** argv)
     cube->dist = 10;
 
     puglSetViewString(view, PUGL_WINDOW_TITLE, "Pugl Window Demo");
-    puglSetPosition(view,
-                    (PuglCoord)(pad + (128U + pad) * i),
-                    (PuglCoord)(pad + (128U + pad) * i));
+    puglSetPositionHint(view,
+                        PUGL_DEFAULT_POSITION,
+                        (PuglCoord)(pad + (128U + pad) * i),
+                        (PuglCoord)(pad + (128U + pad) * i));
 
     puglSetSizeHint(view, PUGL_DEFAULT_SIZE, 512, 512);
     puglSetSizeHint(view, PUGL_MIN_SIZE, 128, 128);

--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -955,9 +955,27 @@ typedef enum {
    size gracefully.
 */
 typedef enum {
-  PUGL_DEFAULT_SIZE, ///< Default size
-  PUGL_MIN_SIZE,     ///< Minimum size
-  PUGL_MAX_SIZE,     ///< Maximum size
+  /**
+     Default size.
+
+     This is used as the size during window creation as a default, if no other
+     size is specified.
+  */
+  PUGL_DEFAULT_SIZE,
+
+  /**
+     Minimum size.
+
+     If set, the view's size should be constrained to be at least this large.
+  */
+  PUGL_MIN_SIZE,
+
+  /**
+     Maximum size.
+
+     If set, the view's size should be constrained to be at most this large.
+  */
+  PUGL_MAX_SIZE,
 
   /**
      Fixed aspect ratio.

--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -948,6 +948,60 @@ typedef enum {
 } PuglViewType;
 
 /**
+   A hint for configuring/constraining the position of a view.
+
+   The system will attempt to make the view's window adhere to these, but they
+   are suggestions, not hard constraints.  Applications should handle any view
+   position gracefully.
+
+   An unset position has `INT16_MIN` (-32768) for both `x` and `y`.  This sigil
+   is chosen because it makes the range of coordinates, -32767 to 32767,
+   conveniently symmetric.  In practice, set positions should be between -16000
+   and 16000 for portability.  Usually the position `{0, 0}` is (near) the
+   top-left of the (or a) display.
+*/
+typedef enum {
+  /**
+     Default position.
+
+     This is used as the position during window creation as a default, if no
+     other position is specified.  It isn't necessary to set a default position
+     (unlike the default size, which is required).  If not even a default
+     position is set, then the window will be created at an arbitrary position.
+     This position is a best-effort attempt to do the most reasonable thing for
+     the initial display of the window, for example, by centering.  Note that
+     it is implementation-defined, subject to change, platform-specific, and
+     for embedded views, may no longer make sense if the parent's size is
+     adjusted.  Code that wants to make assumptions about the initial position
+     must set the default to a specific valid one, such as `{0, 0}`.
+  */
+  PUGL_DEFAULT_POSITION,
+
+  /**
+     Program-specified position.
+
+     This should be used for any position that is determined by the program, as
+     opposed to being specified by the user.  This includes views that
+     manipulate their own position (which is highly discouraged).  Typically,
+     it overrides the default position.
+  */
+  PUGL_CALCULATED_POSITION,
+
+  /**
+     User-specified position.
+
+     This should be used for any position that is more or less directly set by
+     the user, for example by dragging the view, or by explicitly setting some
+     configuration value.  Typically, it overrides the calculated (and in turn
+     the default) position.
+  */
+  PUGL_USER_POSITION,
+} PuglPositionHint;
+
+/// The number of #PuglPositionHint values
+#define PUGL_NUM_POSITION_HINTS ((unsigned)PUGL_USER_POSITION + 1U)
+
+/**
    A hint for configuring/constraining the size of a view.
 
    The system will attempt to make the view's window adhere to these, but they
@@ -1209,6 +1263,23 @@ puglSetPosition(PuglView* view, int x, int y);
 PUGL_API
 PuglStatus
 puglSetSize(PuglView* view, unsigned width, unsigned height);
+
+/**
+   Set a position hint for the view.
+
+   This can be used to set the default, program-calculated, or user-specified
+   position of a view.
+
+   This should be called before puglRealize() so the initial window for the
+   view can be configured correctly.  It may also be used dynamically after the
+   window is realized, for some hints.
+
+   @return An error code on failure, but always succeeds if the view is not yet
+   realized.
+*/
+PUGL_API
+PuglStatus
+puglSetPositionHint(PuglView* view, PuglPositionHint hint, int x, int y);
 
 /**
    Set a size hint for the view.

--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -1245,26 +1245,6 @@ PuglStatus
 puglSetFrame(PuglView* view, PuglRect frame);
 
 /**
-   Set the current position of the view.
-
-   @return #PUGL_UNKNOWN_ERROR on failure, in which case the view frame is
-   unchanged.
-*/
-PUGL_API
-PuglStatus
-puglSetPosition(PuglView* view, int x, int y);
-
-/**
-   Set the current size of the view.
-
-   @return #PUGL_UNKNOWN_ERROR on failure, in which case the view frame is
-   unchanged.
-*/
-PUGL_API
-PuglStatus
-puglSetSize(PuglView* view, unsigned width, unsigned height);
-
-/**
    Set a position hint for the view.
 
    This can be used to set the default, program-calculated, or user-specified
@@ -2231,6 +2211,32 @@ puglRequestAttention(PuglView* view)
 {
   return puglSetViewStyle(view,
                           puglGetViewStyle(view) | PUGL_VIEW_STYLE_DEMANDING);
+}
+
+/**
+   Set the current position of the view.
+
+   @return #PUGL_UNKNOWN_ERROR on failure, in which case the view frame is
+   unchanged.
+*/
+static inline PUGL_DEPRECATED_BY("puglSetPositionHint")
+PuglStatus
+puglSetPosition(PuglView* view, int x, int y)
+{
+  return puglSetPositionHint(view, PUGL_CALCULATED_POSITION, x, y);
+}
+
+/**
+   Set the current size of the view.
+
+   @return #PUGL_UNKNOWN_ERROR on failure, in which case the view frame is
+   unchanged.
+*/
+static inline PUGL_DEPRECATED_BY("puglSetSizeHint")
+PuglStatus
+puglSetSize(PuglView* view, unsigned width, unsigned height)
+{
+  return puglSetSizeHint(view, PUGL_CALCULATED_SIZE, width, height);
 }
 
 #endif // PUGL_DISABLE_DEPRECATED

--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -38,6 +38,8 @@ PUGL_BEGIN_DECLS
 */
 typedef int16_t PuglCoord;
 
+#define PUGL_COORD_INVALID INT16_MIN
+
 /**
    A pixel span (width or height) within/of a view.
 
@@ -45,6 +47,8 @@ typedef int16_t PuglCoord;
    between 1 and 10000.
 */
 typedef uint16_t PuglSpan;
+
+#define PUGL_SPAN_INVALID 0
 
 /**
    A rectangle in a view or on the screen.

--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -964,6 +964,27 @@ typedef enum {
   PUGL_DEFAULT_SIZE,
 
   /**
+     Program-specified size.
+
+     This should be used for any size that is determined by the program, as
+     opposed to being specified by the user.  This includes views that
+     manipulate their own size (although this is generally discouraged), for
+     example to accomodate expanding contents.  Typically, it overrides the
+     default size.
+  */
+  PUGL_CALCULATED_SIZE,
+
+  /**
+     User-specified size.
+
+     This should be used for any size that is more or less directly set by the
+     user, for example by dragging the view's frame, or by explicitly setting
+     some configuration value.  Typically, it overrides the calculated (and in
+     turn the default) position.
+  */
+  PUGL_USER_SIZE,
+
+  /**
      Minimum size.
 
      If set, the view's size should be constrained to be at least this large.
@@ -1196,10 +1217,11 @@ puglSetSize(PuglView* view, unsigned width, unsigned height);
    as well as the supported range of aspect ratios.
 
    This should be called before puglRealize() so the initial window for the
-   view can be configured correctly.
+   view can be configured correctly.  It may also be used dynamically after the
+   window is realized, for some hints.
 
-   @return #PUGL_UNKNOWN_ERROR on failure, but always succeeds if the view is
-   not yet realized.
+   @return An error code on failure, but always succeeds if the view is not yet
+   realized.
 */
 PUGL_API
 PuglStatus

--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -1227,8 +1227,8 @@ PUGL_API
 PuglStatus
 puglSetSizeHint(PuglView*    view,
                 PuglSizeHint hint,
-                PuglSpan     width,
-                PuglSpan     height);
+                unsigned     width,
+                unsigned     height);
 
 /**
    @}

--- a/src/common.c
+++ b/src/common.c
@@ -141,8 +141,12 @@ puglNewView(PuglWorld* const world)
   view->world                           = world;
   view->sizeHints[PUGL_MIN_SIZE].width  = 1;
   view->sizeHints[PUGL_MIN_SIZE].height = 1;
-  view->defaultX                        = INT_MIN;
-  view->defaultY                        = INT_MIN;
+
+  // Set all position hints to invalid
+  for (int i = 0; i < PUGL_NUM_POSITION_HINTS; ++i) {
+    view->positionHints[i].x = PUGL_COORD_INVALID;
+    view->positionHints[i].y = PUGL_COORD_INVALID;
+  }
 
   puglSetDefaultHints(view->hints);
 
@@ -292,16 +296,15 @@ puglGetFrame(const PuglView* view)
   }
 
   // Get the default position if set, or fallback to (0, 0)
-  int x = view->defaultX;
-  int y = view->defaultY;
-  if (x < INT16_MIN || x > INT16_MAX || y < INT16_MIN || y > INT16_MAX) {
-    x = 0;
-    y = 0;
+  PuglPoint pos = view->positionHints[PUGL_DEFAULT_POSITION];
+  if (!puglIsValidPosition(pos)) {
+    pos.x = 0;
+    pos.y = 0;
   }
 
   // Return the default frame, sanitized if necessary
-  const PuglRect frame = {(PuglCoord)x,
-                          (PuglCoord)y,
+  const PuglRect frame = {pos.x,
+                          pos.y,
                           view->sizeHints[PUGL_DEFAULT_SIZE].width,
                           view->sizeHints[PUGL_DEFAULT_SIZE].height};
   return frame;

--- a/src/internal.c
+++ b/src/internal.c
@@ -12,6 +12,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+bool
+puglIsValidSize(const PuglViewSize size)
+{
+  return size.width && size.height;
+}
+
 void
 puglEnsureHint(PuglView* const view, const PuglViewHint hint, const int value)
 {
@@ -123,12 +129,6 @@ puglDecodeUTF8(const uint8_t* buf)
   return 0xFFFD;
 }
 
-static inline bool
-isValidSize(const double width, const double height)
-{
-  return width > 0.0 && height > 0.0;
-}
-
 PuglStatus
 puglPreRealize(PuglView* const view)
 {
@@ -143,8 +143,7 @@ puglPreRealize(PuglView* const view)
   }
 
   // Ensure that the default size is set to a valid size
-  const PuglViewSize defaultSize = view->sizeHints[PUGL_DEFAULT_SIZE];
-  if (!isValidSize(defaultSize.width, defaultSize.height)) {
+  if (!puglIsValidSize(view->sizeHints[PUGL_DEFAULT_SIZE])) {
     return PUGL_BAD_CONFIGURATION;
   }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -18,6 +18,16 @@ puglIsValidSize(const PuglViewSize size)
   return size.width && size.height;
 }
 
+PuglViewSize
+puglHintedSize(const PuglView* const view)
+{
+  return puglIsValidSize(view->sizeHints[PUGL_USER_SIZE])
+           ? view->sizeHints[PUGL_USER_SIZE]
+         : puglIsValidSize(view->sizeHints[PUGL_CALCULATED_SIZE])
+           ? view->sizeHints[PUGL_CALCULATED_SIZE]
+           : view->sizeHints[PUGL_DEFAULT_SIZE];
+}
+
 void
 puglEnsureHint(PuglView* const view, const PuglViewHint hint, const int value)
 {

--- a/src/internal.c
+++ b/src/internal.c
@@ -13,9 +13,25 @@
 #include <string.h>
 
 bool
+puglIsValidPosition(const PuglPoint pos)
+{
+  return (pos.x > INT16_MIN && pos.y > INT16_MIN);
+}
+
+bool
 puglIsValidSize(const PuglViewSize size)
 {
   return size.width && size.height;
+}
+
+PuglPoint
+puglHintedPosition(const PuglView* const view)
+{
+  return puglIsValidPosition(view->positionHints[PUGL_USER_POSITION])
+           ? view->positionHints[PUGL_USER_POSITION]
+         : puglIsValidPosition(view->positionHints[PUGL_CALCULATED_POSITION])
+           ? view->positionHints[PUGL_CALCULATED_POSITION]
+           : view->positionHints[PUGL_DEFAULT_POSITION];
 }
 
 PuglViewSize

--- a/src/internal.c
+++ b/src/internal.c
@@ -15,13 +15,14 @@
 bool
 puglIsValidPosition(const PuglPoint pos)
 {
-  return (pos.x > INT16_MIN && pos.y > INT16_MIN);
+  return (pos.x != PUGL_COORD_INVALID && pos.y != PUGL_COORD_INVALID);
 }
 
 bool
 puglIsValidSize(const PuglViewSize size)
 {
-  return size.width && size.height;
+  return  (size.width != PUGL_SPAN_INVALID) && 
+          (size.height != PUGL_SPAN_INVALID);
 }
 
 PuglPoint

--- a/src/internal.h
+++ b/src/internal.h
@@ -12,10 +12,15 @@
 #include "pugl/attributes.h"
 #include "pugl/pugl.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 PUGL_BEGIN_DECLS
+
+/// Return true if `size` is a valid view size
+bool
+puglIsValidSize(PuglViewSize size);
 
 /// Set hint to a default value if it is unset (PUGL_DONT_CARE)
 void

--- a/src/internal.h
+++ b/src/internal.h
@@ -22,6 +22,10 @@ PUGL_BEGIN_DECLS
 bool
 puglIsValidSize(PuglViewSize size);
 
+/// Return the current size described by the view hints
+PuglViewSize
+puglHintedSize(const PuglView* view);
+
 /// Set hint to a default value if it is unset (PUGL_DONT_CARE)
 void
 puglEnsureHint(PuglView* view, PuglViewHint hint, int value);

--- a/src/internal.h
+++ b/src/internal.h
@@ -18,9 +18,17 @@
 
 PUGL_BEGIN_DECLS
 
+/// Return true if `pos` is a valid view position
+bool
+puglIsValidPosition(PuglPoint pos);
+
 /// Return true if `size` is a valid view size
 bool
 puglIsValidSize(PuglViewSize size);
+
+/// Return the current position described by the view hints
+PuglPoint
+puglHintedPosition(const PuglView* view);
 
 /// Return the current size described by the view hints
 PuglViewSize

--- a/src/mac.m
+++ b/src/mac.m
@@ -343,7 +343,7 @@ dispatchCurrentChildViewConfiguration(PuglView* const view)
 {
   const PuglViewSize defaultSize = puglview->sizeHints[PUGL_DEFAULT_SIZE];
 
-  return (defaultSize.width && defaultSize.height)
+  return puglIsValidSize(defaultSize)
            ? sizePoints(puglview, defaultSize.width, defaultSize.height)
            : NSMakeSize(NSViewNoInstrinsicMetric, NSViewNoInstrinsicMetric);
 }
@@ -1083,7 +1083,7 @@ updateSizeHint(PuglView* const view, const PuglSizeHint hint)
 {
   const PuglSpan width  = view->sizeHints[hint].width;
   const PuglSpan height = view->sizeHints[hint].height;
-  if (!width || !height) {
+  if (!puglIsValidSize(view->sizeHints[hint])) {
     return PUGL_FAILURE;
   }
 
@@ -1238,8 +1238,7 @@ puglRealize(PuglView* view)
                                  NSLayoutRelationGreaterThanOrEqual,
                                  view->sizeHints[PUGL_MIN_SIZE].height)];
 
-  if (view->sizeHints[PUGL_MAX_SIZE].width &&
-      view->sizeHints[PUGL_MAX_SIZE].height) {
+  if (puglIsValidSize(view->sizeHints[PUGL_MAX_SIZE])) {
     [impl->wrapperView
       addConstraint:puglConstraint(impl->wrapperView,
                                    NSLayoutAttributeWidth,

--- a/src/mac.m
+++ b/src/mac.m
@@ -1131,14 +1131,11 @@ getInitialFrame(PuglView* const view)
     return frame;
   }
 
-  const int x = view->defaultX;
-  const int y = view->defaultY;
-  if (x >= INT16_MIN && x <= INT16_MAX && y >= INT16_MIN && y <= INT16_MAX) {
+  const PuglPoint pos = view->positionHints[PUGL_DEFAULT_POSITION];
+  if (puglIsValidPosition(pos)) {
     // Use the default position set with puglSetPosition while unrealized
-    const PuglRect frame = {(PuglCoord)x,
-                            (PuglCoord)y,
-                            view->sizeHints[PUGL_DEFAULT_SIZE].width,
-                            view->sizeHints[PUGL_DEFAULT_SIZE].height};
+    const PuglRect frame = {
+      pos.x, pos.y, defaultWidth, defaultHeight};
     return frame;
   }
 
@@ -1698,8 +1695,8 @@ puglSetFrame(PuglView* view, const PuglRect frame)
 
   if (!impl->wrapperView) {
     // Set defaults to be used when realized
-    view->defaultX                            = frame.x;
-    view->defaultY                            = frame.y;
+    view->positionHints[PUGL_DEFAULT_POSITION].x = frame.x;
+    view->positionHints[PUGL_DEFAULT_POSITION].y = frame.y;
     view->sizeHints[PUGL_DEFAULT_SIZE].width  = (PuglSpan)frame.width;
     view->sizeHints[PUGL_DEFAULT_SIZE].height = (PuglSpan)frame.height;
     return PUGL_SUCCESS;
@@ -1805,8 +1802,11 @@ puglSetPositionHint(PuglView* const        view,
 
   const PuglPoint newHintedPos = puglHintedPosition(view);
 
-  if (view->impl->win && view->lastConfigure.x == oldHintedPos.x &&
-      view->lastConfigure.y == oldHintedPos.y &&
+  if (view->impl->win && 
+      (view->lastConfigure.x == oldHintedPos.x || 
+        PUGL_COORD_INVALID == oldHintedPos.x) &&
+      (view->lastConfigure.y == oldHintedPos.y || 
+        PUGL_COORD_INVALID == oldHintedPos.y) &&
       (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
     return puglSetWindowPosition(view, newHintedPos.x, newHintedPos.y);
   }

--- a/src/mac.m
+++ b/src/mac.m
@@ -1816,10 +1816,26 @@ puglSetSizeHint(PuglView* const    view,
     return PUGL_BAD_PARAMETER;
   }
 
+  const PuglViewSize oldHintedSize = puglHintedSize(view);
+
   view->sizeHints[hint].width  = width;
   view->sizeHints[hint].height = height;
 
-  return view->impl->window ? updateSizeHint(view, hint) : PUGL_SUCCESS;
+  const PuglViewSize newHintedSize = puglHintedSize(view);
+
+  const PuglStatus st =
+    view->impl->window ? updateSizeHint(view, hint) : PUGL_SUCCESS;
+
+  PuglInternals* const impl = view->impl;
+  if (!st && impl->wrapperView &&
+      view->lastConfigure.width == oldHintedSize.width &&
+      view->lastConfigure.height == oldHintedSize.height &&
+      (newHintedSize.width != oldHintedSize.width ||
+       newHintedSize.height != oldHintedSize.height)) {
+    return puglSetSize(view, hint, newHintedSize.width, newHintedSize.height);
+  }
+
+  return st;
 }
 
 PuglStatus

--- a/src/mac.m
+++ b/src/mac.m
@@ -1807,6 +1807,32 @@ puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
 }
 
 PuglStatus
+puglSetPositionHint(PuglView* const        view,
+                    const PuglPositionHint hint,
+                    const int              x,
+                    const int              y)
+{
+  if (x <= INT16_MIN || x > INT16_MAX || y <= INT16_MIN || y > INT16_MAX) {
+    return PUGL_BAD_PARAMETER;
+  }
+
+  const PuglPoint oldHintedPos = puglHintedPosition(view);
+
+  view->positionHints[hint].x = (PuglCoord)x;
+  view->positionHints[hint].y = (PuglCoord)y;
+
+  const PuglPoint newHintedPos = puglHintedPosition(view);
+
+  if (view->impl->win && view->lastConfigure.x == oldHintedPos.x &&
+      view->lastConfigure.y == oldHintedPos.y &&
+      (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
+    return puglSetPosition(view, newHintedPos.x, newHintedPos.y);
+  }
+
+  return PUGL_SUCCESS;
+}
+
+PuglStatus
 puglSetSizeHint(PuglView* const    view,
                 const PuglSizeHint hint,
                 const unsigned     width,

--- a/src/mac.m
+++ b/src/mac.m
@@ -1730,20 +1730,10 @@ puglSetFrame(PuglView* view, const PuglRect frame)
   return dispatchCurrentChildViewConfiguration(view);
 }
 
-PuglStatus
-puglSetPosition(PuglView* const view, const int x, const int y)
+static PuglStatus
+puglSetWindowPosition(PuglView* const view, const int x, const int y)
 {
-  if (x < INT16_MIN || x > INT16_MAX || y < INT16_MIN || y > INT16_MAX) {
-    return PUGL_BAD_PARAMETER;
-  }
-
   PuglInternals* const impl = view->impl;
-  if (!impl->wrapperView) {
-    // Set defaults to be used when realized
-    view->defaultX = x;
-    view->defaultY = y;
-    return PUGL_SUCCESS;
-  }
 
   const PuglRect frame = {(PuglCoord)x,
                           (PuglCoord)y,
@@ -1769,20 +1759,12 @@ puglSetPosition(PuglView* const view, const int x, const int y)
   return dispatchCurrentChildViewConfiguration(view);
 }
 
-PuglStatus
-puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
+static PuglStatus
+puglSetWindowSize(PuglView* const view,
+                  const unsigned  width,
+                  const unsigned  height)
 {
-  if (width > INT16_MAX || height > INT16_MAX) {
-    return PUGL_BAD_PARAMETER;
-  }
-
   PuglInternals* const impl = view->impl;
-  if (!impl->wrapperView) {
-    // Set defaults to be used when realized
-    view->sizeHints[PUGL_DEFAULT_SIZE].width  = (PuglSpan)width;
-    view->sizeHints[PUGL_DEFAULT_SIZE].height = (PuglSpan)height;
-    return PUGL_SUCCESS;
-  }
 
   if (impl->window) {
     // Adjust top-level window frame
@@ -1826,7 +1808,7 @@ puglSetPositionHint(PuglView* const        view,
   if (view->impl->win && view->lastConfigure.x == oldHintedPos.x &&
       view->lastConfigure.y == oldHintedPos.y &&
       (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
-    return puglSetPosition(view, newHintedPos.x, newHintedPos.y);
+    return puglSetWindowPosition(view, newHintedPos.x, newHintedPos.y);
   }
 
   return PUGL_SUCCESS;
@@ -1859,7 +1841,8 @@ puglSetSizeHint(PuglView* const    view,
       view->lastConfigure.height == oldHintedSize.height &&
       (newHintedSize.width != oldHintedSize.width ||
        newHintedSize.height != oldHintedSize.height)) {
-    return puglSetSize(view, hint, newHintedSize.width, newHintedSize.height);
+    return puglSetWindowSize(
+      view, hint, newHintedSize.width, newHintedSize.height);
   }
 
   return st;

--- a/src/mac.m
+++ b/src/mac.m
@@ -1809,17 +1809,18 @@ puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
 PuglStatus
 puglSetSizeHint(PuglView* const    view,
                 const PuglSizeHint hint,
-                const PuglSpan     width,
-                const PuglSpan     height)
+                const unsigned     width,
+                const unsigned     height)
 {
-  if ((unsigned)hint >= PUGL_NUM_SIZE_HINTS) {
+  if ((unsigned)hint >= PUGL_NUM_SIZE_HINTS || width > INT16_MAX ||
+      height > INT16_MAX) {
     return PUGL_BAD_PARAMETER;
   }
 
   const PuglViewSize oldHintedSize = puglHintedSize(view);
 
-  view->sizeHints[hint].width  = width;
-  view->sizeHints[hint].height = height;
+  view->sizeHints[hint].width  = (PuglSpan)width;
+  view->sizeHints[hint].height = (PuglSpan)height;
 
   const PuglViewSize newHintedSize = puglHintedSize(view);
 

--- a/src/types.h
+++ b/src/types.h
@@ -60,8 +60,6 @@ struct PuglViewImpl {
   PuglPoint          positionHints[PUGL_NUM_POSITION_HINTS];
   PuglViewSize       sizeHints[PUGL_NUM_SIZE_HINTS];
   char*              strings[PUGL_NUM_STRING_HINTS];
-  int                defaultX;
-  int                defaultY;
   PuglViewStage      stage;
   bool               resizing;
 };

--- a/src/types.h
+++ b/src/types.h
@@ -57,6 +57,7 @@ struct PuglViewImpl {
   uintptr_t          transientParent;
   PuglConfigureEvent lastConfigure;
   PuglHints          hints;
+  PuglPoint          positionHints[PUGL_NUM_POSITION_HINTS];
   PuglViewSize       sizeHints[PUGL_NUM_SIZE_HINTS];
   char*              strings[PUGL_NUM_STRING_HINTS];
   int                defaultX;

--- a/src/win.c
+++ b/src/win.c
@@ -738,7 +738,8 @@ handleMessage(PuglView* view, UINT message, WPARAM wParam, LPARAM lParam)
     handleConfigure(view, &event);
     break;
   case WM_SIZING:
-    if (view->sizeHints[PUGL_MIN_ASPECT].width) {
+    if (puglIsValidSize(view->sizeHints[PUGL_MIN_ASPECT]) &&
+        puglIsValidSize(view->sizeHints[PUGL_MAX_ASPECT])) {
       constrainAspect(view, (RECT*)lParam, wParam);
       return TRUE;
     }
@@ -770,8 +771,7 @@ handleMessage(PuglView* view, UINT message, WPARAM wParam, LPARAM lParam)
     mmi                   = (MINMAXINFO*)lParam;
     mmi->ptMinTrackSize.x = view->sizeHints[PUGL_MIN_SIZE].width;
     mmi->ptMinTrackSize.y = view->sizeHints[PUGL_MIN_SIZE].height;
-    if (view->sizeHints[PUGL_MAX_SIZE].width &&
-        view->sizeHints[PUGL_MAX_SIZE].height) {
+    if (puglIsValidSize(view->sizeHints[PUGL_MAX_SIZE])) {
       mmi->ptMaxTrackSize.x = view->sizeHints[PUGL_MAX_SIZE].width;
       mmi->ptMaxTrackSize.y = view->sizeHints[PUGL_MAX_SIZE].height;
     }

--- a/src/win.c
+++ b/src/win.c
@@ -1306,10 +1306,11 @@ puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
 PuglStatus
 puglSetSizeHint(PuglView* const    view,
                 const PuglSizeHint hint,
-                const PuglSpan     width,
-                const PuglSpan     height)
+                const unsigned     width,
+                const unsigned     height)
 {
-  if ((unsigned)hint >= PUGL_NUM_SIZE_HINTS) {
+  if ((unsigned)hint >= PUGL_NUM_SIZE_HINTS || width > INT16_MAX ||
+      height > INT16_MAX) {
     return PUGL_BAD_PARAMETER;
   }
 

--- a/src/win.c
+++ b/src/win.c
@@ -1242,13 +1242,9 @@ puglSetFrame(PuglView* view, const PuglRect frame)
            : PUGL_UNKNOWN_ERROR;
 }
 
-PuglStatus
-puglSetPosition(PuglView* const view, const int x, const int y)
+static PuglStatus
+puglSetWindowPosition(PuglView* const view, const int x, const int y)
 {
-  if (x < INT16_MIN || x > INT16_MAX || y < INT16_MIN || y > INT16_MAX) {
-    return PUGL_BAD_PARAMETER;
-  }
-
   if (!view->impl->hwnd) {
     // Set defaults to be used when realized
     view->defaultX = x;
@@ -1271,13 +1267,9 @@ puglSetPosition(PuglView* const view, const int x, const int y)
            : PUGL_UNKNOWN_ERROR;
 }
 
-PuglStatus
-puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
+static PuglStatus
+puglSetWindowSize(PuglView* const view, const unsigned width, const unsigned height)
 {
-  if (width > INT16_MAX || height > INT16_MAX) {
-    return PUGL_BAD_PARAMETER;
-  }
-
   if (!view->impl->hwnd) {
     // Set defaults to be used when realized
     view->sizeHints[PUGL_DEFAULT_SIZE].width  = (PuglSpan)width;
@@ -1323,7 +1315,7 @@ puglSetPositionHint(PuglView* const        view,
   if (view->impl->hwnd && view->lastConfigure.x == oldHintedPos.x &&
       view->lastConfigure.y == oldHintedPos.y &&
       (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
-    return puglSetPosition(view, hint, newHintedPos.x, newHintedPos.y);
+    return puglSetWindowPosition(view, hint, newHintedPos.x, newHintedPos.y);
   }
 
   return PUGL_SUCCESS;
@@ -1351,7 +1343,7 @@ puglSetSizeHint(PuglView* const    view,
       view->lastConfigure.height == oldHintedSize.height &&
       (newHintedSize.width != oldHintedSize.width ||
        newHintedSize.height != oldHintedSize.height)) {
-    return puglSetSize(view, newHintedSize.width, newHintedSize.height);
+    return puglSetWindowSize(view, newHintedSize.width, newHintedSize.height);
   }
 
   return PUGL_SUCCESS;

--- a/src/win.c
+++ b/src/win.c
@@ -1221,8 +1221,8 @@ puglSetFrame(PuglView* view, const PuglRect frame)
 {
   if (!view->impl->hwnd) {
     // Set defaults to be used when realized
-    view->defaultX                            = frame.x;
-    view->defaultY                            = frame.y;
+    view->positionHints[PUGL_DEFAULT_POSITION].x = frame.x;
+    view->positionHints[PUGL_DEFAULT_POSITION].y = frame.y;
     view->sizeHints[PUGL_DEFAULT_SIZE].width  = (PuglSpan)frame.width;
     view->sizeHints[PUGL_DEFAULT_SIZE].height = (PuglSpan)frame.height;
     return PUGL_SUCCESS;
@@ -1247,8 +1247,8 @@ puglSetWindowPosition(PuglView* const view, const int x, const int y)
 {
   if (!view->impl->hwnd) {
     // Set defaults to be used when realized
-    view->defaultX = x;
-    view->defaultY = y;
+    view->positionHints[PUGL_DEFAULT_POSITION].x = x;
+    view->positionHints[PUGL_DEFAULT_POSITION].y = y;
     return PUGL_SUCCESS;
   }
 
@@ -1312,8 +1312,11 @@ puglSetPositionHint(PuglView* const        view,
 
   const PuglPoint newHintedPos = puglHintedPosition(view);
 
-  if (view->impl->hwnd && view->lastConfigure.x == oldHintedPos.x &&
-      view->lastConfigure.y == oldHintedPos.y &&
+  if (view->impl->win && 
+      (view->lastConfigure.x == oldHintedPos.x || 
+        PUGL_COORD_INVALID == oldHintedPos.x) &&
+      (view->lastConfigure.y == oldHintedPos.y || 
+        PUGL_COORD_INVALID == oldHintedPos.y) &&
       (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
     return puglSetWindowPosition(view, hint, newHintedPos.x, newHintedPos.y);
   }
@@ -1575,12 +1578,11 @@ getInitialFrame(PuglView* const view)
 
   const PuglSpan defaultWidth  = view->sizeHints[PUGL_DEFAULT_SIZE].width;
   const PuglSpan defaultHeight = view->sizeHints[PUGL_DEFAULT_SIZE].height;
-  const int      x             = view->defaultX;
-  const int      y             = view->defaultY;
-  if (x >= INT16_MIN && x <= INT16_MAX && y >= INT16_MIN && y <= INT16_MAX) {
+  const PuglPoint pos          = view->positionHints[PUGL_DEFAULT_POSITION];
+  if (puglIsValidPosition(pos)) {
     // Use the default position set with puglSetPosition while unrealized
     const PuglRect frame = {
-      (PuglCoord)x, (PuglCoord)y, defaultWidth, defaultHeight};
+      pos.x, pos.y, defaultWidth, defaultHeight};
     return frame;
   }
 

--- a/src/win.c
+++ b/src/win.c
@@ -1304,6 +1304,32 @@ puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
 }
 
 PuglStatus
+puglSetPositionHint(PuglView* const        view,
+                    const PuglPositionHint hint,
+                    const int              x,
+                    const int              y)
+{
+  if (x <= INT16_MIN || x > INT16_MAX || y <= INT16_MIN || y > INT16_MAX) {
+    return PUGL_BAD_PARAMETER;
+  }
+
+  const PuglPoint oldHintedPos = puglHintedPosition(view);
+
+  view->positionHints[hint].x = (PuglCoord)x;
+  view->positionHints[hint].y = (PuglCoord)y;
+
+  const PuglPoint newHintedPos = puglHintedPosition(view);
+
+  if (view->impl->hwnd && view->lastConfigure.x == oldHintedPos.x &&
+      view->lastConfigure.y == oldHintedPos.y &&
+      (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
+    return puglSetPosition(view, hint, newHintedPos.x, newHintedPos.y);
+  }
+
+  return PUGL_SUCCESS;
+}
+
+PuglStatus
 puglSetSizeHint(PuglView* const    view,
                 const PuglSizeHint hint,
                 const unsigned     width,

--- a/src/win.c
+++ b/src/win.c
@@ -1313,8 +1313,20 @@ puglSetSizeHint(PuglView* const    view,
     return PUGL_BAD_PARAMETER;
   }
 
+  const PuglViewSize oldHintedSize = puglHintedSize(view);
+
   view->sizeHints[hint].width  = width;
   view->sizeHints[hint].height = height;
+
+  const PuglViewSize newHintedSize = puglHintedSize(view);
+
+  if (view->impl->hwnd && view->lastConfigure.width == oldHintedSize.width &&
+      view->lastConfigure.height == oldHintedSize.height &&
+      (newHintedSize.width != oldHintedSize.width ||
+       newHintedSize.height != oldHintedSize.height)) {
+    return puglSetSize(view, newHintedSize.width, newHintedSize.height);
+  }
+
   return PUGL_SUCCESS;
 }
 

--- a/src/x11.c
+++ b/src/x11.c
@@ -1998,10 +1998,11 @@ puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
 PuglStatus
 puglSetSizeHint(PuglView* const    view,
                 const PuglSizeHint hint,
-                const PuglSpan     width,
-                const PuglSpan     height)
+                const unsigned     width,
+                const unsigned     height)
 {
-  if ((unsigned)hint >= PUGL_NUM_SIZE_HINTS) {
+  if ((unsigned)hint >= PUGL_NUM_SIZE_HINTS || width > INT16_MAX ||
+      height > INT16_MAX) {
     return PUGL_BAD_PARAMETER;
   }
 

--- a/src/x11.c
+++ b/src/x11.c
@@ -378,21 +378,21 @@ updateSizeHints(const PuglView* const view)
     sizeHints.max_height  = (int)frame.height;
   } else {
     const PuglViewSize defaultSize = view->sizeHints[PUGL_DEFAULT_SIZE];
-    if (defaultSize.width && defaultSize.height) {
+    if (puglIsValidSize(defaultSize)) {
       sizeHints.flags |= PBaseSize;
       sizeHints.base_width  = defaultSize.width;
       sizeHints.base_height = defaultSize.height;
     }
 
     const PuglViewSize minSize = view->sizeHints[PUGL_MIN_SIZE];
-    if (minSize.width && minSize.height) {
+    if (puglIsValidSize(minSize)) {
       sizeHints.flags |= PMinSize;
       sizeHints.min_width  = minSize.width;
       sizeHints.min_height = minSize.height;
     }
 
     const PuglViewSize maxSize = view->sizeHints[PUGL_MAX_SIZE];
-    if (maxSize.width && maxSize.height) {
+    if (puglIsValidSize(maxSize)) {
       sizeHints.flags |= PMaxSize;
       sizeHints.max_width  = maxSize.width;
       sizeHints.max_height = maxSize.height;
@@ -400,8 +400,7 @@ updateSizeHints(const PuglView* const view)
 
     const PuglViewSize minAspect = view->sizeHints[PUGL_MIN_ASPECT];
     const PuglViewSize maxAspect = view->sizeHints[PUGL_MAX_ASPECT];
-    if (minAspect.width && minAspect.height && maxAspect.width &&
-        maxAspect.height) {
+    if (puglIsValidSize(minAspect) && puglIsValidSize(maxAspect)) {
       sizeHints.flags |= PAspect;
       sizeHints.min_aspect.x = minAspect.width;
       sizeHints.min_aspect.y = minAspect.height;
@@ -410,7 +409,7 @@ updateSizeHints(const PuglView* const view)
     }
 
     const PuglViewSize fixedAspect = view->sizeHints[PUGL_FIXED_ASPECT];
-    if (fixedAspect.width && fixedAspect.height) {
+    if (puglIsValidSize(fixedAspect)) {
       sizeHints.flags |= PAspect;
       sizeHints.min_aspect.x = fixedAspect.width;
       sizeHints.min_aspect.y = fixedAspect.height;

--- a/src/x11.c
+++ b/src/x11.c
@@ -1986,6 +1986,10 @@ puglSetSizeHint(PuglView* const    view,
                 const PuglSpan     width,
                 const PuglSpan     height)
 {
+  if ((unsigned)hint >= PUGL_NUM_SIZE_HINTS) {
+    return PUGL_BAD_PARAMETER;
+  }
+
   view->sizeHints[hint].width  = width;
   view->sizeHints[hint].height = height;
   return updateSizeHints(view);

--- a/src/x11.c
+++ b/src/x11.c
@@ -518,12 +518,11 @@ getInitialFrame(PuglView* const view)
 
   const PuglSpan defaultWidth  = view->sizeHints[PUGL_DEFAULT_SIZE].width;
   const PuglSpan defaultHeight = view->sizeHints[PUGL_DEFAULT_SIZE].height;
-  const int      x             = view->defaultX;
-  const int      y             = view->defaultY;
-  if (x >= INT16_MIN && x <= INT16_MAX && y >= INT16_MIN && y <= INT16_MAX) {
+  const PuglPoint pos          = view->positionHints[PUGL_DEFAULT_POSITION];
+  if (puglIsValidPosition(pos)) {
     // Use the default position set with puglSetPosition while unrealized
     const PuglRect frame = {
-      (PuglCoord)x, (PuglCoord)y, defaultWidth, defaultHeight};
+      pos.x, pos.y, defaultWidth, defaultHeight};
     return frame;
   }
 
@@ -1950,10 +1949,10 @@ puglSetFrame(PuglView* const view, const PuglRect frame)
 {
   if (!view->impl->win) {
     // Set defaults to be used when realized
-    view->defaultX                            = frame.x;
-    view->defaultY                            = frame.y;
-    view->sizeHints[PUGL_DEFAULT_SIZE].width  = frame.width;
-    view->sizeHints[PUGL_DEFAULT_SIZE].height = frame.height;
+    view->positionHints[PUGL_DEFAULT_POSITION].x = frame.x;
+    view->positionHints[PUGL_DEFAULT_POSITION].y = frame.y;
+    view->sizeHints[PUGL_DEFAULT_SIZE].width     = frame.width;
+    view->sizeHints[PUGL_DEFAULT_SIZE].height    = frame.height;
     return PUGL_SUCCESS;
   }
 
@@ -2006,8 +2005,11 @@ puglSetPositionHint(PuglView* const        view,
 
   const PuglPoint newHintedPos = puglHintedPosition(view);
 
-  if (view->impl->win && view->lastConfigure.x == oldHintedPos.x &&
-      view->lastConfigure.y == oldHintedPos.y &&
+  if (view->impl->win && 
+      (view->lastConfigure.x == oldHintedPos.x || 
+        PUGL_COORD_INVALID == oldHintedPos.x) &&
+      (view->lastConfigure.y == oldHintedPos.y || 
+        PUGL_COORD_INVALID == oldHintedPos.y) &&
       (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
     return puglSetWindowPosition(view, newHintedPos.x, newHintedPos.y);
   }

--- a/src/x11.c
+++ b/src/x11.c
@@ -1967,23 +1967,10 @@ puglSetFrame(PuglView* const view, const PuglRect frame)
            : PUGL_UNKNOWN_ERROR;
 }
 
-PuglStatus
-puglSetPosition(PuglView* const view, const int x, const int y)
+static PuglStatus
+puglSetWindowPosition(PuglView* const view, const int x, const int y)
 {
-  Display* const display = view->world->impl->display;
-
-  if (x < INT16_MIN || x > INT16_MAX || y < INT16_MIN || y > INT16_MAX) {
-    return PUGL_BAD_PARAMETER;
-  }
-
-  if (!view->impl->win) {
-    // Set defaults to be used when realized
-    view->defaultX = x;
-    view->defaultY = y;
-    return PUGL_SUCCESS;
-  }
-
-  return XMoveWindow(display,
+  return XMoveWindow(view->world->impl->display,
                      view->impl->win,
                      (int)(x - view->impl->frameExtentLeft),
                      (int)(y - view->impl->frameExtentTop))
@@ -1991,23 +1978,13 @@ puglSetPosition(PuglView* const view, const int x, const int y)
            : PUGL_UNKNOWN_ERROR;
 }
 
-PuglStatus
-puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
+static PuglStatus
+puglSetWindowSize(PuglView* const view,
+                  const unsigned  width,
+                  const unsigned  height)
 {
-  Display* const display = view->world->impl->display;
-
-  if (width > INT16_MAX || height > INT16_MAX) {
-    return PUGL_BAD_PARAMETER;
-  }
-
-  if (!view->impl->win) {
-    // Set defaults to be used when realized
-    view->sizeHints[PUGL_DEFAULT_SIZE].width  = (PuglSpan)width;
-    view->sizeHints[PUGL_DEFAULT_SIZE].height = (PuglSpan)height;
-    return PUGL_SUCCESS;
-  }
-
-  return XResizeWindow(display, view->impl->win, width, height)
+  return XResizeWindow(
+           view->world->impl->display, view->impl->win, width, height)
            ? PUGL_SUCCESS
            : PUGL_UNKNOWN_ERROR;
 }
@@ -2032,7 +2009,7 @@ puglSetPositionHint(PuglView* const        view,
   if (view->impl->win && view->lastConfigure.x == oldHintedPos.x &&
       view->lastConfigure.y == oldHintedPos.y &&
       (newHintedPos.x != oldHintedPos.x || newHintedPos.y != oldHintedPos.y)) {
-    return puglSetPosition(view, newHintedPos.x, newHintedPos.y);
+    return puglSetWindowPosition(view, newHintedPos.x, newHintedPos.y);
   }
 
   return PUGL_SUCCESS;
@@ -2060,12 +2037,7 @@ puglSetSizeHint(PuglView* const    view,
       view->lastConfigure.height == oldHintedSize.height &&
       (newHintedSize.width != oldHintedSize.width ||
        newHintedSize.height != oldHintedSize.height)) {
-    return XResizeWindow(view->world->impl->display,
-                         view->impl->win,
-                         newHintedSize.width,
-                         newHintedSize.height)
-             ? PUGL_SUCCESS
-             : PUGL_UNKNOWN_ERROR;
+    return puglSetWindowSize(view, newHintedSize.width, newHintedSize.height);
   }
 
   return PUGL_SUCCESS;

--- a/test/test_cairo.c
+++ b/test/test_cairo.c
@@ -66,7 +66,7 @@ main(int argc, char** argv)
   puglSetBackend(test.view, puglCairoBackend());
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 128, 896);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 128, 896);
   puglShow(test.view, PUGL_SHOW_RAISE);
 
   // Drive event loop until the view gets exposed

--- a/test/test_cursor.c
+++ b/test/test_cursor.c
@@ -52,7 +52,7 @@ main(int argc, char** argv)
   puglSetBackend(test.view, puglStubBackend());
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 896, 640);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 896, 640);
   puglShow(test.view, PUGL_SHOW_RAISE);
 
   // Drive event loop until the view gets exposed

--- a/test/test_gl.c
+++ b/test/test_gl.c
@@ -85,7 +85,7 @@ main(int argc, char** argv)
   puglSetBackend(test.view, puglGlBackend());
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 384, 896);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 384, 896);
   puglShow(test.view, PUGL_SHOW_RAISE);
 
   // Enter OpenGL context as if setting things up

--- a/test/test_gl_free_unrealized.c
+++ b/test/test_gl_free_unrealized.c
@@ -36,7 +36,7 @@ main(int argc, char** argv)
   puglSetBackend(test.view, puglGlBackend());
   puglSetHandle(test.view, &test);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 640, 896);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 640, 896);
 
   assert(!puglGetVisible(test.view));
 

--- a/test/test_gl_hints.c
+++ b/test/test_gl_hints.c
@@ -35,7 +35,7 @@ main(void)
   puglSetBackend(view, puglGlBackend());
   puglSetEventFunc(view, onEvent);
   puglSetSizeHint(view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(view, 128, 128);
+  puglSetPositionHint(view, PUGL_DEFAULT_POSITION, 128, 128);
 
   // Check invalid cases
   assert(puglSetViewHint(view, PUGL_CONTEXT_API, PUGL_DONT_CARE) ==

--- a/test/test_local_copy_paste.c
+++ b/test/test_local_copy_paste.c
@@ -133,7 +133,7 @@ main(int argc, char** argv)
   puglSetHandle(app.view, &app);
   puglSetEventFunc(app.view, onEvent);
   puglSetSizeHint(app.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(app.view, 384, 128);
+  puglSetPositionHint(app.view, PUGL_DEFAULT_POSITION, 384, 128);
 
   // Create and show window
   assert(!puglRealize(app.view));

--- a/test/test_realize.c
+++ b/test/test_realize.c
@@ -75,7 +75,7 @@ main(int argc, char** argv)
   assert(puglRealize(test.view) == PUGL_BAD_CONFIGURATION);
 
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 640, 128);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 640, 128);
 
   // Create initially invisible window
   assert(!puglRealize(test.view));

--- a/test/test_redisplay.c
+++ b/test/test_redisplay.c
@@ -117,7 +117,7 @@ main(int argc, char** argv)
   puglSetHandle(test.view, &test);
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 896, 128);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 896, 128);
 
   // Create and show window
   assert(!puglRealize(test.view));

--- a/test/test_remote_copy_paste.c
+++ b/test/test_remote_copy_paste.c
@@ -148,7 +148,7 @@ main(int argc, char** argv)
   puglSetHandle(app.copierView, &app);
   puglSetEventFunc(app.copierView, onCopierEvent);
   puglSetSizeHint(app.copierView, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(app.copierView, 640, 896);
+  puglSetPositionHint(app.copierView, PUGL_DEFAULT_POSITION, 640, 896);
 
   // Set up paster view
   app.pasterView = puglNewView(app.world);
@@ -158,7 +158,7 @@ main(int argc, char** argv)
   puglSetHandle(app.pasterView, &app);
   puglSetEventFunc(app.pasterView, onPasterEvent);
   puglSetSizeHint(app.pasterView, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(app.pasterView, 896, 896);
+  puglSetPositionHint(app.pasterView, PUGL_DEFAULT_POSITION, 896, 896);
 
   // Create and show both views
   assert(!puglShow(app.copierView, PUGL_SHOW_RAISE));

--- a/test/test_show_hide.c
+++ b/test/test_show_hide.c
@@ -115,7 +115,7 @@ main(int argc, char** argv)
   puglSetHandle(test.view, &test);
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 128, 384);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 128, 384);
 
   // Create initially invisible window
   assert(!puglRealize(test.view));

--- a/test/test_size.c
+++ b/test/test_size.c
@@ -87,7 +87,7 @@ main(int argc, char** argv)
   puglSetSizeHint(test.view, PUGL_MIN_SIZE, minSize, minSize);
   puglSetSizeHint(test.view, PUGL_MAX_SIZE, maxSize, maxSize);
   puglSetSizeHint(test.view, PUGL_FIXED_ASPECT, 1, 1);
-  puglSetPosition(test.view, 384, 384);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 384, 384);
 
   // Create and show window
   assert(!puglRealize(test.view));

--- a/test/test_stub.c
+++ b/test/test_stub.c
@@ -52,7 +52,7 @@ main(int argc, char** argv)
   puglSetBackend(test.view, puglStubBackend());
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 384, 896);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 384, 896);
   puglShow(test.view, PUGL_SHOW_RAISE);
 
   // Drive event loop until the view gets exposed

--- a/test/test_stub_hints.c
+++ b/test/test_stub_hints.c
@@ -35,7 +35,7 @@ main(void)
   puglSetBackend(view, puglStubBackend());
   puglSetEventFunc(view, onEvent);
   puglSetSizeHint(view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(view, 640, 384);
+  puglSetPositionHint(view, PUGL_DEFAULT_POSITION, 640, 384);
 
   // Check invalid cases
   assert(puglSetViewHint(view, (PuglViewHint)-1, 0) == PUGL_BAD_PARAMETER);

--- a/test/test_timer.c
+++ b/test/test_timer.c
@@ -112,7 +112,7 @@ main(int argc, char** argv)
   puglSetHandle(test.view, &test);
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 896, 384);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 896, 384);
 
   // Create and show window
   assert(!puglRealize(test.view));

--- a/test/test_update.c
+++ b/test/test_update.c
@@ -90,7 +90,7 @@ main(int argc, char** argv)
   puglSetHandle(test.view, &test);
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 128, 640);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 128, 640);
 
   // Create and show window
   assert(!puglRealize(test.view));

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -73,7 +73,7 @@ main(int argc, char** argv)
   puglSetHandle(test.view, &test);
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 384, 640);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 384, 640);
 
   // Check basic accessors
   assert(puglGetBackend(test.view) == puglStubBackend());

--- a/test/test_vulkan.c
+++ b/test/test_vulkan.c
@@ -172,7 +172,7 @@ main(int argc, char** argv)
   puglSetBackend(test.view, puglVulkanBackend());
   puglSetEventFunc(test.view, onEvent);
   puglSetSizeHint(test.view, PUGL_DEFAULT_SIZE, 256, 256);
-  puglSetPosition(test.view, 640, 640);
+  puglSetPositionHint(test.view, PUGL_DEFAULT_POSITION, 640, 640);
   assert(!puglRealize(test.view));
 
   // Create Vulkan surface for window


### PR DESCRIPTION
`puglSetPositionHint()` was without any effect if called prior `puglRealize()`. The main reason was that the "use the default position" condition in `getInitialFrame()` wasn't fulfilled and thus not used. The fallback for this was the window center algorithm which caused clipping in the majority of the LV2 hosts. And I just *started* to use the new position hints.

I made changes as discussed in #98. Win and mac edits were mainly copy/pasted from x11 but not tested.

I know you are currently working on this drafted branch. Feel free to take it, or get inspiration, or do something else with it. 