### PR TITLE
Fix creation zero-sized uis in jalv, ardour

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -419,7 +419,7 @@ updateSizeHints(const PuglView* const view)
     }
   }
 
-  XSetNormalHints(display, view->impl->win, &sizeHints);
+  XSetWMNormalHints(display, view->impl->win, &sizeHints);
   return PUGL_SUCCESS;
 }
 


### PR DESCRIPTION
Me again ;-). Now I found a solution for the 2 years old issue #42 which is closed but not fixed yet.

Problem description:
Pugl-based Plugin UIs are realized in jalv and ardour with size zero (or maybe (1, 1) - I'm not sure) if no `ui_resize()` (provided as LV2 feature) is called instantly. Even if `puglSetSize()` or `puglSetSizeHint()` is called prior `puglRealize()`. jalv addidtionally prints error messages on the screen. To visualize the problem (jalv with B.Amp at 100x100 (but not displayed) is in top left):
![Bildschirmfoto von 2023-02-18 21-46-22](https://user-images.githubusercontent.com/42939779/219899498-2456c857-95fc-4561-834b-a48de3906fc3.png)

`ui:resize` became deprecated as requested by faktx (AFAIK, didn't check). The *manual* resize mechanism (dragging) without resize as feature or interface fully works in jalv, ardour, reaper, zrythm, and carla. This was also one of the reasons to deprecate. Only the zero size-intitialized UIs in jalv and ardour stopped me to remove `resize` from my code, yet.

Solution:
I saw that @brummer10 uses `XSetWMNormalHints()` instead of `XSetNormalHints()`. 

Tests:
This works with all hosts tested (jalv, ardour, reaper, zrythm, carla, qtractor) without any error message. Also my standalone test apps (like B.Widgets widgetgallery) work as expected. 

Note:
Calling `puglSetSize()` or `puglSetSizeHint()` *after*  `puglRealize()` still produces different host-dependent results. Only to keep in mind, no TODO for now.
