### PR TITLE
tests: print modifiers for key events

### DIFF
--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -293,17 +293,19 @@ printEvent(const PuglEvent* event, const char* prefix, const bool verbose)
   case PUGL_UNREALIZE:
     return fprintf(stderr, "%sUnrealize\n", prefix);
   case PUGL_KEY_PRESS:
-    return PRINT("%sKey press   code %3u key  U+%04X (%s)\n",
+    return (PRINT("%sKey press   code %3u key  U+%04X (%s) ",
                  prefix,
                  event->key.keycode,
                  event->key.key,
-                 keyString(event->key.key));
+                 keyString(event->key.key)) +
+            printModifiers(event->scroll.state));
   case PUGL_KEY_RELEASE:
-    return PRINT("%sKey release code %3u key  U+%04X (%s)\n",
+    return (PRINT("%sKey release code %3u key  U+%04X (%s) ",
                  prefix,
                  event->key.keycode,
                  event->key.key,
-                 keyString(event->key.key));
+                 keyString(event->key.key)) +
+            printModifiers(event->scroll.state));
   case PUGL_TEXT:
     return PRINT("%sText entry  code %3u char U+%04X (%s)\n",
                  prefix,


### PR DESCRIPTION
Adds modifiers to the prints during key events, needed in order to verify the ticket at #111
