### PR TITLE
x11: fix keyboard input with control modifier active

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -880,8 +880,8 @@ translateKey(PuglView* const view, XEvent* const xevent, PuglEvent* const event)
 
   event->key.keycode = xevent->xkey.keycode;
 
-  // Mask off the shift bit to get the lowercase "main" symbol
-  xevent->xkey.state = xevent->xkey.state & ~(unsigned)ShiftMask;
+  // Mask off the control and shift bits to get the lowercase "main" symbol
+  xevent->xkey.state = xevent->xkey.state & ~(unsigned)(ControlMask|ShiftMask);
 
   // Lookup unshifted key
   char          ustr[8] = {0};


### PR DESCRIPTION
In X11, using Ubuntu 22.04 KDE Plasma desktop, I could not get proper keyboard events while the control key was held down.

I added a print right after the x11 utf8 key decode, like so:
```
  printf("x11 special:%d ufound:%d key:%d:'%c' %02x:%02x:'%s'\n",
           special, ufound, event->key.key, event->key.key, ustr[0], ustr[1], ustr);
```

And this was the print out for Ctrl+C:

```
x11 special:0 ufound:1 key:3:'' 03:00:''
```

After the fix from this PR, the following is printed, and yes it then works as expected:

```
x11 special:0 ufound:1 key:99:'c' 63:00:'c'
```
