### PR TITLE
X11: Only call XSetTransientForHint for valid windows

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -2042,7 +2042,7 @@ puglSetTransientParent(PuglView* const view, const PuglNativeView parent)
 
   view->transientParent = parent;
 
-  if (view->impl->win) {
+  if (view->impl->win && view->transientParent) {
     XSetTransientForHint(
       display, view->impl->win, (Window)view->transientParent);
   }


### PR DESCRIPTION
While testing a few different WMs, noticed this warning from metacity:

```
(metacity:586692): metacity-WARNING **: 15:11:43.796: Invalid WM_TRANSIENT_FOR window 0x0 specified for 0x5c00002 (Cardinal).
```

PR fixes it by ensuring the transient parent is valid (non-zero).
