### PR TITLE
quick and dirty hack to generate text events for numpad keys

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -890,14 +890,14 @@ translateKey(PuglView* const view, XEvent* const xevent, PuglEvent* const event)
   KeySym        sym     = 0;
   const int     ufound  = XLookupString(&xevent->xkey, ustr, 8, &sym, NULL);
   const PuglKey special = keySymToSpecial(sym);
-  if (special) {
+  if (special && ufound <= 0) {
     event->key.state = puglFilterMods(event->key.state, special);
     event->key.key   = special;
   } else if (ufound > 0) {
     event->key.key = (PuglKey)puglDecodeUTF8((const uint8_t*)ustr);
   }
 
-  if (xevent->type == KeyPress && !filter && !special && view->impl->xic) {
+  if (xevent->type == KeyPress && !filter && !(special && ufound <= 0) && view->impl->xic) {
     // Lookup shifted key for possible text event
     xevent->xkey.state = state;
 


### PR DESCRIPTION
As mentioned in https://github.com/lv2/pugl/issues/121 it would be nice to have some text events for the numpad keys.

 I therefore have prepared a quick and dirty hack to showcase it for Linux X11. I do not recommend to use this in production. It needs to be implemented "properly" and for all the platforms.

I do this in my spare time and I am definitely no expert in X11 coding, so I don't know if I did this properly, as said it's just a hack (you have been warned :-))

I cannot provide solutions for the other platforms, I only have Linux machines.

