### PR TITLE
Fix macOS embed UI resize from host

### DIFF
--- a/src/mac.m
+++ b/src/mac.m
@@ -188,13 +188,18 @@ getCurrentViewStyleFlags(PuglView* const view)
 }
 
 static PuglStatus
-dispatchCurrentChildViewConfiguration(PuglView* const view)
+dispatchCurrentChildViewConfiguration(PuglView* const view, bool drawViewResize)
 {
   const NSRect framePt = [view->impl->wrapperView frame];
   const NSRect framePx = nsRectFromPoints(view, framePt);
 
   if (view->stage < PUGL_VIEW_STAGE_REALIZED) {
     return PUGL_SUCCESS;
+  }
+
+  if (drawViewResize) {
+    const NSSize sizePt = [view->impl->drawView convertSizeFromBacking:framePx.size];
+    [view->impl->drawView setFrameSize:sizePt];
   }
 
   const PuglConfigureEvent ev = {
@@ -317,7 +322,7 @@ dispatchCurrentChildViewConfiguration(PuglView* const view)
     if (puglview->impl->window) {
       [puglview->impl->window dispatchCurrentConfiguration];
     } else {
-      dispatchCurrentChildViewConfiguration(puglview);
+      dispatchCurrentChildViewConfiguration(puglview, true);
     }
     reshaped = false;
   }
@@ -1767,7 +1772,7 @@ puglSetFrame(PuglView* view, const PuglRect frame)
 
   [impl->wrapperView setFrame:framePt];
   [impl->drawView setFrame:sizePt];
-  return dispatchCurrentChildViewConfiguration(view);
+  return dispatchCurrentChildViewConfiguration(view, false);
 }
 
 PuglStatus
@@ -1806,7 +1811,7 @@ puglSetPosition(PuglView* const view, const int x, const int y)
   [impl->drawView setFrameOrigin:drawPt.origin];
 
   // Dispatch new configuration
-  return dispatchCurrentChildViewConfiguration(view);
+  return dispatchCurrentChildViewConfiguration(view, false);
 }
 
 PuglStatus
@@ -1843,7 +1848,7 @@ puglSetSize(PuglView* const view, const unsigned width, const unsigned height)
   [impl->drawView setFrameSize:drawPt.size];
 
   // Dispatch new configuration
-  return dispatchCurrentChildViewConfiguration(view);
+  return dispatchCurrentChildViewConfiguration(view, false);
 }
 
 PuglStatus


### PR DESCRIPTION
Initially discovered in https://github.com/trummerschlunk/PodcastPlugins/issues/22

Ardour does not currently support fixed-size LV2 UIs, it always allows resizing.
This works fine on Linux/X11 but was causing some odd issues on macos, related to the ticket above.

When resizing through the plugin ui (and Ardour then adjust to it), everything seems well.
After some tests I noticed that the opengl draw (ns)view did not have the correct size applied when resized from the host, even though the main wrapper view did.

Maybe we assumed that `[impl->wrapperView setAutoresizesSubviews:YES];` would be enough, but it is clearly not, leading to this issue.

Fix is possible by forcing the draw view to be resized, only done for the cases where we dont set size just before