### PR TITLE
X11: fix BadWindow for embedded windows when the parent is destroyed

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -1190,6 +1190,9 @@ translateEvent(PuglView* const view, XEvent xevent)
     view->impl->mapped = false;
     event              = makeConfigureEvent(view);
     break;
+  case DestroyNotify:
+    view->impl->win = None;
+    break;
   case ConfigureNotify:
     event                  = makeConfigureEvent(view);
     event.configure.width  = (PuglSpan)xevent.xconfigure.width;


### PR DESCRIPTION
This pull request fixes a crash in plugin context in several DAWs (mainly Bitwig) where the host destroys the parent window before calling the GUI destroy function (`clap_plugin_gui::destroy` for CLAP or `IPlugView::removed` in VST3). 

Calling `puglFreeView` there would result in a crash due to calling `XDestroyWindow` for a non-existent (already destroyed) window. This bug is possible in any situation in which a parent window is destroyed before we can call `puglFreeView`.

Fortunately the fix is straightforward, X11 provides a way to know when our window was destroyed by listening to `DestroyNotify` event.