### PR TITLE
Fix regression in X11 puglSetPositionHint

### DIFF
--- a/src/x11.c
+++ b/src/x11.c
@@ -1955,10 +1955,13 @@ puglGetScaleFactor(const PuglView* const view)
 static PuglStatus
 puglSetWindowPosition(PuglView* const view, const int x, const int y)
 {
-  return puglX11Status(XMoveWindow(view->world->impl->display,
-                                   view->impl->win,
-                                   (int)(x - view->impl->frameExtentLeft),
-                                   (int)(y - view->impl->frameExtentTop)));
+  return !view->impl->win
+           ? PUGL_SUCCESS
+           : puglX11Status(XMoveWindow(
+               view->world->impl->display,
+               view->impl->win,
+               (int)(x - view->impl->frameExtentLeft),
+               (int)(y - view->impl->frameExtentTop)));
 }
 
 static PuglStatus


### PR DESCRIPTION
There was a regression after updating pugl within DPF which had the call:
```c
puglSetPosition(view, x, y);
```

And then converted into:
```c
puglSetPositionHint(view, PUGL_CURRENT_POSITION, x, y);
```

The old pugl had this code:
```c
  if (!view->impl->win) {
    // Set defaults to be used when realized
    view->sizeHints[PUGL_DEFAULT_SIZE].width  = (PuglSpan)width;
    view->sizeHints[PUGL_DEFAULT_SIZE].height = (PuglSpan)height;
    return PUGL_SUCCESS;
  }
```

While new pugl uses:
```c
  return (hint == PUGL_CURRENT_POSITION) ? puglSetWindowPosition(view, x, y)
                                         : PUGL_SUCCESS;
```
That `puglSetWindowPosition` calls into X11 without checking if the view has been realized, and this is the regression.

New code could in theory check if the view is realized, but I don't think there is a need for that.
If we look at `puglSetWindowSize` function, that has checks in place.
So to be consistent I added it inside `puglSetWindowPosition` which fixes DPF.
