### PR TITLE
Process all messages if running as Windows standalone

### DIFF
--- a/src/win.c
+++ b/src/win.c
@@ -1088,7 +1088,8 @@ puglDispatchViewEvents(PuglView* view)
 
   long markTime = 0;
   MSG  msg;
-  while (PeekMessage(&msg, view->impl->hwnd, 0, 0, PM_REMOVE)) {
+  HWND hwnd = view->world->type == PUGL_PROGRAM ? NULL : view->impl->hwnd;
+  while (PeekMessage(&msg, hwnd, 0, 0, PM_REMOVE)) {
     if (msg.message == PUGL_LOCAL_MARK_MSG) {
       markTime = GetMessageTime();
     } else {


### PR DESCRIPTION
When running as standalone (world type set to `PUGL_PROGRAM`) I noticed that the handling of external non-pugl managed windows were not being processed. Everything was working fine when running as a plugin, but not when running as standalone.

It's hard to give an example as my usecase is related to web views, which is quite complex.
When researching the issue I came across this https://github.com/MicrosoftEdge/WebView2Feedback/issues/920 which lead me to this fix, their situation is very similar.

I think the change is reasonable - if we run as standalone, process all messages and not just the ones related to the current pugl-world.

The only bad side effect I can see is that this breaks the use of multiple pugl-world instances in a standalone application - but would that be a supported scenario, or a good usecase to have?
