### PR TITLE
Adjust PUGL_KEY_F11, PUGL_KEY_F12

### DIFF
--- a/include/pugl/pugl.h
+++ b/include/pugl/pugl.h
@@ -297,8 +297,8 @@ typedef enum {
   PUGL_KEY_F8            = 0xE007U, ///< F8
   PUGL_KEY_F9            = 0xE008U, ///< F9
   PUGL_KEY_F10           = 0xE009U, ///< F10
-  PUGL_KEY_F11           = 0xE010U, ///< F11
-  PUGL_KEY_F12           = 0xE011U, ///< F12
+  PUGL_KEY_F11           = 0xE00AU, ///< F11
+  PUGL_KEY_F12           = 0xE00BU, ///< F12
   PUGL_KEY_PAGE_UP       = 0xE031U, ///< Page Up
   PUGL_KEY_PAGE_DOWN     = 0xE032U, ///< Page Down
   PUGL_KEY_END           = 0xE033U, ///< End

--- a/src/mac.m
+++ b/src/mac.m
@@ -848,30 +848,41 @@ flagDiffers(const uint32_t lhs, const uint32_t rhs, const uint32_t mask)
   return (lhs & mask) != (rhs & mask);
 }
 
+static bool
+isFlagSet(const uint32_t i, uint32_t mask)
+{
+  return (i & mask) > 0;
+}
+
 - (void)flagsChanged:(NSEvent*)event
 {
   const uint32_t mods    = getModifiers(event);
+  PuglEventType  type    = PUGL_NOTHING;
   PuglKey        special = PUGL_KEY_NONE;
 
   const uint16_t keyCode = [event keyCode];
   if (flagDiffers(mods, puglview->impl->mods, PUGL_MOD_SHIFT)) {
     special = (keyCode == 0x3C) ? PUGL_KEY_SHIFT_R : PUGL_KEY_SHIFT_L;
+    type = isFlagSet(mods, PUGL_MOD_SHIFT) ? PUGL_KEY_PRESS : PUGL_KEY_RELEASE;
   } else if (flagDiffers(mods, puglview->impl->mods, PUGL_MOD_CTRL)) {
     special = (keyCode == 0x3E) ? PUGL_KEY_CTRL_R : PUGL_KEY_CTRL_L;
+    type = isFlagSet(mods, PUGL_MOD_CTRL) ? PUGL_KEY_PRESS : PUGL_KEY_RELEASE;
   } else if (flagDiffers(mods, puglview->impl->mods, PUGL_MOD_ALT)) {
     special = (keyCode == 0x3D) ? PUGL_KEY_ALT_R : PUGL_KEY_ALT_L;
+    type = isFlagSet(mods, PUGL_MOD_ALT) ? PUGL_KEY_PRESS : PUGL_KEY_RELEASE;
   } else if (flagDiffers(mods, puglview->impl->mods, PUGL_MOD_SUPER)) {
     special = PUGL_KEY_SUPER_L; // Left and right command are identical
+    type = isFlagSet(mods, PUGL_MOD_SUPER) ? PUGL_KEY_PRESS : PUGL_KEY_RELEASE;
   } else if (flagDiffers(mods, puglview->impl->mods, PUGL_MOD_CAPS_LOCK)) {
     special = PUGL_KEY_CAPS_LOCK;
+    type = isFlagSet(mods, PUGL_MOD_CAPS_LOCK) ? PUGL_KEY_PRESS : PUGL_KEY_RELEASE;
   }
 
   if (special != 0) {
     const NSPoint wloc    = [self eventLocation:event];
     const NSPoint rloc    = [NSEvent mouseLocation];
-    const bool    release = [event type] == NSEventTypeKeyUp;
 
-    const PuglKeyEvent ev = {release ? PUGL_KEY_RELEASE : PUGL_KEY_PRESS,
+    const PuglKeyEvent ev = {type,
                              0U,
                              [event timestamp],
                              wloc.x,


### PR DESCRIPTION
mac.m depends on contiguous F-key numbering:
if (sym >= NSF1FunctionKey && sym <= NSF12FunctionKey) {
      return (PuglKey)(PUGL_KEY_F1 + (sym - NSF1FunctionKey));
}
I have tested this with Pugl Event Printer (try F12).
